### PR TITLE
Run 10x more inner iterations of Richards.

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -82,7 +82,7 @@ VMS = {
 
 BENCHMARKS = {
     'binarytrees': 18,
-    'richards': 100,
+    'richards': 1000,
     'spectralnorm': 3000,
     'nbody': 1000000,
     'fasta': 1000000,


### PR DESCRIPTION
On bencher3 this brings an outer iteration from ~0.04 to ~0.4. In other words, I checked that  running 10x more inner iterations yields a runtime also 10x longer (some benchmarks don't scale linearly like this).

Fixes a bug in another repo: https://github.com/softdevteam/krun/issues/35
