### PR TITLE
Graal tweaks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -180,8 +180,11 @@ build_jdk() {
 MX_REPO=https://bitbucket.org/allr/mx
 GRAAL_REPO=http://hg.openjdk.java.net/graal/graal-compiler
 GRAAL_VERSION=9dafd1dc5ff9
+# Building with the JDK we built earlier is troublesome (SSL+maven issues).
+# Instead we use the system JDK8.
+SYSTEM_JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 
-MX="env DEFAULT_VM=jvmci JAVA_HOME=${wrkdir}/openjdk/build/linux-x86_64-normal-server-release/images/j2sdk-image/ python2.7 ${wrkdir}/mx/mx.py"
+MX="env DEFAULT_VM=jvmci JAVA_HOME=${SYSTEM_JAVA_HOME} python2.7 ${wrkdir}/mx/mx.py"
 build_graal() {
 	echo "\n===> Download and build graal\n"
 

--- a/warmup.krun
+++ b/warmup.krun
@@ -1,6 +1,7 @@
 import os
-from krun.vm_defs import (PythonVMDef, LuaVMDef, JavaVMDef, GraalVMDef, PHPVMDef,
-		           JRubyTruffleVMDef, V8VMDef)
+from krun.vm_defs import (PythonVMDef, LuaVMDef, JavaVMDef, GraalVMDef,
+		          PHPVMDef, JRubyTruffleVMDef, V8VMDef,
+			  find_internal_jvmci_java_bin)
 from krun import EntryPoint
 
 # Who to mail
@@ -41,7 +42,7 @@ VMS = {
 		'warm_upon_iter': 0,
 	},
 	'Graal': {
-		'vm_def': GraalVMDef('work/jvmci/jdk1.8.0-internal/product/bin/java', JDK8_HOME),
+		'vm_def': GraalVMDef(find_internal_jvmci_java_bin('work/jvmci/'), JDK8_HOME),
 		'variants': ['default-java'],
 		'n_iterations': ITERATIONS_ALL_VMS,
 		'warm_upon_iter': 0,
@@ -60,7 +61,7 @@ VMS = {
 	},
 	'JRubyTruffle' : {
 		'vm_def': JRubyTruffleVMDef('work/jruby/bin/jruby',
-		                            java_path='work/jvmci/jdk1.8.0-internal/product/bin/java'),
+		                            java_path=find_internal_jvmci_java_bin('work/jvmci/')),
 		'variants': ['default-ruby'],
 		'n_iterations': ITERATIONS_ALL_VMS,
 		'warm_upon_iter': 0,


### PR DESCRIPTION
Tweaks to make the Graal branch build on bencher2.

For some reason we are unable to build the jvmci using the jdk8 built from source. Something in maven barfs over SSL. Probably a configuration issue.

Fix suggested by Chris: use the system jdk8 to build jvmci.

Fixes the issue for me.

OK?
