### PR TITLE
Assume fasta checksums will not overflow or saturate.

### DIFF
--- a/benchmarks/fasta/c/bench.c
+++ b/benchmarks/fasta/c/bench.c
@@ -43,7 +43,7 @@ const amino homosapiens[] = {
 /* Expected checksum tied to this specific scale factor */
 #define SCALE 10000
 #define EXPECT_CKSUM 9611973
-static u_int32_t checksum = 0;
+static u_int64_t checksum = 0;
 
 static unsigned rseed = START_RAND_SEED;
 
@@ -146,7 +146,7 @@ void run_iter(int n) {
       rand_fasta(homosapiens, SCALE * 5);
 
       if (checksum != EXPECT_CKSUM) {
-         errx(EXIT_FAILURE, "checksum fail: %u vs %u",
+         errx(EXIT_FAILURE, "checksum fail: %lu vs %u",
 	     checksum, EXPECT_CKSUM);
       }
 

--- a/benchmarks/fasta/java/fasta.java
+++ b/benchmarks/fasta/java/fasta.java
@@ -15,11 +15,6 @@ class ChecksumOutputStream extends OutputStream {
      */
 
     private long checksum = 0;
-    private static long MOD;
-
-    public ChecksumOutputStream() {
-        MOD = (long) Math.pow(2, 32);
-    }
 
     public void reset() {
         checksum = 0;
@@ -29,7 +24,6 @@ class ChecksumOutputStream extends OutputStream {
         for (int i = 0; i < len; i++) {
             checksum += b[off + i];
         }
-        checksum  = checksum % MOD;
     }
 
     public long getChecksum() {

--- a/benchmarks/fasta/javascript/bench.js
+++ b/benchmarks/fasta/javascript/bench.js
@@ -5,7 +5,6 @@
 
 var INITIAL_STATE = 42;
 var last = INITIAL_STATE, A = 3877, C = 29573, M = 139968;
-var MOD = Math.pow(2, 32);
 
 function rand(max) {
   last = (last * A + C) % M;
@@ -45,7 +44,6 @@ function wrap_print(s) {
     checksum += s.charCodeAt(i);
   }
   checksum += 10; // newline ascii code
-  checksum = checksum % MOD;
 }
 
 function makeCumulative(table) {

--- a/benchmarks/fasta/lua/bench.lua
+++ b/benchmarks/fasta/lua/bench.lua
@@ -6,7 +6,6 @@
 local SCALE = 10000
 local EXPECT_CKSUM = 9611973
 local checksum = 0
-local MOD = math.pow(2, 32)
 
 local INITIAL_STATE = 42
 local Last = INITIAL_STATE
@@ -22,7 +21,6 @@ function wrap_write(...)
   for i = 1, #str do
     checksum = checksum + string.byte(str, i)
   end
-  checksum = checksum % MOD
 end
 
 local function make_repeat_fasta(s, n)
@@ -117,7 +115,7 @@ function run_iter(N)
       make_random_fasta(iub, SCALE*3)
       make_random_fasta(homosapiens, SCALE*5)
 
-      if checksum  ~= EXPECT_CKSUM then
+      if checksum ~= EXPECT_CKSUM then
         print("bad checksum:", EXPECT_CKSUM, "vs", checksum)
         os.exit(1)
       end

--- a/benchmarks/fasta/php/bench.php
+++ b/benchmarks/fasta/php/bench.php
@@ -16,7 +16,6 @@ $last = $INITIAL_STATE;
 $CHECKSUM = 0;
 define("SCALE", 10000);
 define("EXPECT_CKSUM", 9611973);
-define("MOD", pow(2, 32));
 
 function gen_random(&$last, &$randoms, $max = 1.0, $ia = 3877.0, $ic = 29573.0, $im = 139968.0) {
    foreach($randoms as &$r) {
@@ -31,7 +30,6 @@ function wrap_print($s) {
     for ($i = 0; $i < $len; $i++) {
         $CHECKSUM = ($CHECKSUM + ord($s[$i]));
     }
-    $CHECKSUM = $CHECKSUM % MOD;
 }
 
 /* Weighted selection from alphabet */

--- a/benchmarks/fasta/python/bench.py
+++ b/benchmarks/fasta/python/bench.py
@@ -33,7 +33,6 @@ INITIAL_STATE = 42
 CHECKSUM = 0;
 SCALE = 10000
 EXPECT_CKSUM = 9611973
-MOD = 2 ** 32
 
 
 def wrap_print(s):
@@ -45,7 +44,6 @@ def wrap_print(s):
     for ch in s:
         CHECKSUM = (CHECKSUM + ord(ch))
     CHECKSUM += 10  # newline ascii code
-    CHECKSUM = CHECKSUM % MOD
 
 
 def makeCumulative(table):

--- a/benchmarks/fasta/ruby/bench.rb
+++ b/benchmarks/fasta/ruby/bench.rb
@@ -49,14 +49,12 @@ GR_IC = 29573.0
 @SCALE = 10000
 @CHECKSUM = 0
 @EXPECT_CKSUM = 9611973
-@MOD = 2 ** 32
 
 def wrap_puts(s)
     s.each_byte do |i|
         @CHECKSUM = (@CHECKSUM + i)
     end
     @CHECKSUM = @CHECKSUM + 10  # newline
-    @CHECKSUM = @CHECKSUM % @MOD
 end
 
 def make_repeat_fasta(src, n)


### PR DESCRIPTION
This checksum business was intruding my thoughts over the weekend. I have come to peace with the following idea: Let's assume the checksums do not overflow or saturate.

Facts that lead me to think this is a better idea:
- All of the languages we are using support numbers in the range of a signed64. Some as integers, some as doubles.
- Signed64 allows a huge numeric range. Maxing this out would be unlikely.
- If a checksum does exceed this range, it will either over/underflow (in the case of integer types) or saturate (for doubles). In this case, we will know about it (checksum will fail), and thus we can change the benchmark parameters to ensure this does not happen.
- With this assumption, no language has to do modulo's ever. Thus making it fairer.

FWIW here are the "integer" types in our languages:
- C: whatever int type you choose.
- Java: int=signed32, long=signed64.
- JS: int is really a double.
- Lua: int is really a double.
- PHP: Platform dependent, but on our architectures: signed64 and double above this range.
- Python: Bignum
- Ruby Bignum.

I'm pretty sure this is the best we can do. So let's put it to bed and charge on.

CC @snim2 

OK?
