### PR TITLE
More OpenBSD fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ JAVAC = ${PWD}/work/openjdk/build/linux-x86_64-normal-server-release/jdk/bin/jav
 # XXX build our on GCC and plug in
 CC = cc
 
-all: build-vms build-benchmarks build-benchs bench
+all: build-vms build-benchs bench
 
 .PHONY: build-vms build-benchs bench
 

--- a/build.sh
+++ b/build.sh
@@ -379,6 +379,7 @@ fetch_libkalibera() {
 	fi
 }
 
+fetch_external_benchmarks
 case `uname` in
     Linux)
 	fetch_libkalibera
@@ -404,4 +405,3 @@ case `uname` in
 	build_jdk
 	;;
 esac
-fetch_external_benchmarks

--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,7 @@ check_for bash
 check_for java
 check_for javac
 check_for xzdec
+check_for wget
 
 case `uname` in
     OpenBSD)

--- a/patches/v8_various.diff
+++ b/patches/v8_various.diff
@@ -1,5 +1,5 @@
 diff --git a/src/d8.cc b/src/d8.cc
-index feda52a..6e4f0d2 100644
+index b73ab0b..daaebcb 100644
 --- a/src/d8.cc
 +++ b/src/d8.cc
 @@ -2,6 +2,21 @@
@@ -24,7 +24,7 @@ index feda52a..6e4f0d2 100644
  
  // Defined when linking against shared lib on Windows.
  #if defined(USING_V8_SHARED) && !defined(V8_SHARED)
-@@ -562,6 +577,24 @@ void Shell::Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
+@@ -584,6 +599,24 @@ void Shell::Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
    fflush(stdout);
  }
  
@@ -49,21 +49,24 @@ index feda52a..6e4f0d2 100644
  
  void Shell::Write(const v8::FunctionCallbackInfo<v8::Value>& args) {
    for (int i = 0; i < args.Length(); i++) {
-@@ -587,6 +620,30 @@ void Shell::Write(const v8::FunctionCallbackInfo<v8::Value>& args) {
+@@ -611,6 +644,33 @@ void Shell::Write(const v8::FunctionCallbackInfo<v8::Value>& args) {
    }
  }
  
 +void Shell::WriteErr(const v8::FunctionCallbackInfo<v8::Value>& args) {
-+  for (int i = 0; i < args.Length(); i++) {
++  Isolate* isolate = args.GetIsolate();
++  for (int j = 0; j < args.Length(); j++) {
 +    HandleScope handle_scope(args.GetIsolate());
-+    if (i != 0) {
++    if (j != 0) {
 +      printf(" ");
 +    }
 +
 +    // Explicitly catch potential exceptions in toString().
-+    v8::TryCatch try_catch(args.GetIsolate());
-+    Handle<String> str_obj = args[i]->ToString(args.GetIsolate());
-+    if (try_catch.HasCaught()) {
++    v8::TryCatch try_catch(isolate);
++    Local<String> str_obj;
++    if (!args[j]
++             ->ToString(args.GetIsolate()->GetCurrentContext())
++             .ToLocal(&str_obj)) {
 +      try_catch.ReThrow();
 +      return;
 +    }
@@ -80,26 +83,34 @@ index feda52a..6e4f0d2 100644
  
  void Shell::Read(const v8::FunctionCallbackInfo<v8::Value>& args) {
    String::Utf8Value file(args[0]);
-@@ -946,8 +1003,14 @@ Handle<ObjectTemplate> Shell::CreateGlobalTemplate(Isolate* isolate) {
-   Handle<ObjectTemplate> global_template = ObjectTemplate::New(isolate);
-   global_template->Set(String::NewFromUtf8(isolate, "print"),
-                        FunctionTemplate::New(isolate, Print));
-+  global_template->Set(String::NewFromUtf8(isolate, "print_err"),
-+                       FunctionTemplate::New(isolate, PrintErr));
-+  global_template->Set(String::NewFromUtf8(isolate, "clock_gettime_monotonic"),
-+                       FunctionTemplate::New(isolate, ClockGettimeMonotonic));
-   global_template->Set(String::NewFromUtf8(isolate, "write"),
-                        FunctionTemplate::New(isolate, Write));
-+  global_template->Set(String::NewFromUtf8(isolate, "write_err"),
-+                       FunctionTemplate::New(isolate, WriteErr));
-   global_template->Set(String::NewFromUtf8(isolate, "read"),
-                        FunctionTemplate::New(isolate, Read));
-   global_template->Set(String::NewFromUtf8(isolate, "readbuffer"),
+@@ -1058,10 +1118,22 @@ Local<ObjectTemplate> Shell::CreateGlobalTemplate(Isolate* isolate) {
+           .ToLocalChecked(),
+       FunctionTemplate::New(isolate, Print));
+   global_template->Set(
++      String::NewFromUtf8(isolate, "print_err", NewStringType::kNormal)
++          .ToLocalChecked(),
++      FunctionTemplate::New(isolate, PrintErr));
++  global_template->Set(
++      String::NewFromUtf8(isolate, "clock_gettime_monotonic", NewStringType::kNormal)
++          .ToLocalChecked(),
++      FunctionTemplate::New(isolate, ClockGettimeMonotonic));
++  global_template->Set(
+       String::NewFromUtf8(isolate, "write", NewStringType::kNormal)
+           .ToLocalChecked(),
+       FunctionTemplate::New(isolate, Write));
+   global_template->Set(
++      String::NewFromUtf8(isolate, "write_err", NewStringType::kNormal)
++          .ToLocalChecked(),
++      FunctionTemplate::New(isolate, WriteErr));
++  global_template->Set(
+       String::NewFromUtf8(isolate, "read", NewStringType::kNormal)
+           .ToLocalChecked(),
+       FunctionTemplate::New(isolate, Read));
 diff --git a/src/d8.h b/src/d8.h
-index aac6228..b0f13b7 100644
+index 16f612c..33fd78f 100644
 --- a/src/d8.h
 +++ b/src/d8.h
-@@ -300,7 +300,10 @@ class Shell : public i::AllStatic {
+@@ -385,7 +385,10 @@ class Shell : public i::AllStatic {
                               const  PropertyCallbackInfo<void>& info);
  
    static void Print(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -107,6 +118,6 @@ index aac6228..b0f13b7 100644
 +  static void ClockGettimeMonotonic(const v8::FunctionCallbackInfo<v8::Value>& args);
    static void Write(const v8::FunctionCallbackInfo<v8::Value>& args);
 +  static void WriteErr(const v8::FunctionCallbackInfo<v8::Value>& args);
+   static void QuitOnce(v8::FunctionCallbackInfo<v8::Value>* args);
    static void Quit(const v8::FunctionCallbackInfo<v8::Value>& args);
    static void Version(const v8::FunctionCallbackInfo<v8::Value>& args);
-   static void Read(const v8::FunctionCallbackInfo<v8::Value>& args);


### PR DESCRIPTION
This also updates us to a much newer v8, which appears (appears!) to fix the intermittent build error we were previously encountering.

In essence, everything builds on OpenBSD except Graal/Truffle and HHVM. [PyPy currently doesn't build, but that's because of LibreSSL fallout. There should be a new PyPy release in the next week or so which fixes this, so it's not worth patching ourselves.]
