### PR TITLE
Nbody checksums

### DIFF
--- a/benchmarks/nbody/c/bench.c
+++ b/benchmarks/nbody/c/bench.c
@@ -17,7 +17,10 @@
 #define days_per_year 365.24
 
 static double checksum = 0;
-#define EXPECT_CHECKSUM -0.33814926871151740339627167486469261348247528076171875
+#define EXPECT_CHECKSUM -0.3381550232201908645635057837353087961673736572265625
+#define N_ADVANCES 100000
+#define EPSILON 0.0000000000001
+
 
 struct planet {
   double x, y, z;
@@ -147,8 +150,8 @@ void inner_iter(int n)
     n_advance(NBODIES, bodies, 0.01);
   checksum += energy(NBODIES, bodies);
 
-  if (checksum != EXPECT_CHECKSUM) {
-    errx(EXIT_FAILURE, "bad checksum: %.52f vs %52f",
+  if (abs(checksum - EXPECT_CHECKSUM) >= EPSILON) {
+    errx(EXIT_FAILURE, "bad checksum: %.52f vs %.52f",
         checksum, EXPECT_CHECKSUM);
   }
 }
@@ -164,8 +167,7 @@ void run_iter(int n) {
       /* reset global state */
       checksum = 0;
       memcpy(bodies, initial_bodies, sizeof(initial_bodies));
-
-      inner_iter(NBODIES);
+      inner_iter(N_ADVANCES);
    }
 
    free(bodies);

--- a/benchmarks/nbody/java/nbody.java
+++ b/benchmarks/nbody/java/nbody.java
@@ -12,17 +12,29 @@
 
 public final class nbody {
     static void init() {};
+    private static double checksum = 0;
+    private static final int N_ADVANCES = 100000;
+    private static final double EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625;
+    private static final double EPSILON = 0.0000000000001;
 
     public static void runIter(int n) {
-        //int n = Integer.parseInt(args[0]);
+        for (int i = 0; i < n; i++) {
+            inner_iter(N_ADVANCES);
+        }
+    }
 
+    private static void inner_iter(int n) {
+        checksum = 0;
         NBodySystem bodies = new NBodySystem();
-        //System.out.printf("%.9f\n", bodies.energy());
-        bodies.energy();
+        checksum += bodies.energy();
         for (int i=0; i<n; ++i)
            bodies.advance(0.01);
-        //System.out.printf("%.9f\n", bodies.energy());
-        bodies.energy();
+        checksum += bodies.energy();
+
+        if (Math.abs(checksum - EXPECT_CHECKSUM) >= EPSILON) {
+           System.out.println("bad checksum: " + checksum + " vs " + EXPECT_CHECKSUM);
+           System.exit(1);
+        }
     }
 }
 

--- a/benchmarks/nbody/javascript/bench.js
+++ b/benchmarks/nbody/javascript/bench.js
@@ -18,6 +18,10 @@ var SOLAR_MASS = 4 * PI * PI;
  */
 var DAYS_PER_YEAR = 365.24;
 
+var EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625;
+var N_ADVANCES = 100000;
+var EPSILON = 0.0000000000001;
+
 /**
  * @param {number} x
  * @param {number} y
@@ -272,17 +276,26 @@ NBodySystem.prototype.energy = function(){
 /**
  * @param {number} n
  */
-run_iter = function(n) {
+inner_iter = function(n) {
   var bodyBuffer = new ArrayBuffer(Body.BYTES_SIZE * 5);
   var bodies = new NBodySystem( Array( 
      Sun(bodyBuffer, 0),Jupiter(bodyBuffer, 1),
      Saturn(bodyBuffer, 2),Uranus(bodyBuffer, 3),Neptune(bodyBuffer, 4) 
   ));
-  //print(bodies.energy().toFixed(9));
-  bodies.energy().toFixed(9);
+  var checksum = 0;
+
+  checksum += bodies.energy();
   for (var i=0; i<n; i++){ bodies.advance(0.01); }
-  //print(bodies.energy().toFixed(9));
-  bodies.energy().toFixed(9);
+  checksum += bodies.energy();
+
+  if (Math.abs(checksum - EXPECT_CHECKSUM) >= EPSILON) {
+    print("bad checksum: " + checksum + " vs " + EXPECT_CHECKSUM);
+    quit(1);
+  }
 }
 
-//runTest(n);
+function run_iter(n) {
+  for (i=0; i<n; i++) {
+    inner_iter(N_ADVANCES);
+  }
+}

--- a/benchmarks/nbody/lua/bench.lua
+++ b/benchmarks/nbody/lua/bench.lua
@@ -10,48 +10,56 @@ saturn = {}
 uranus = {}
 neptune = {}
 
+local EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625
+local N_ADVANCES = 100000
+local EPSILON = 0.0000000000001
+
 local sqrt = math.sqrt
 
 local PI = 3.141592653589793
 local SOLAR_MASS = 4 * PI * PI
 local DAYS_PER_YEAR = 365.24
-sun.x = 0.0
-sun.y = 0.0
-sun.z = 0.0
-sun.vx = 0.0
-sun.vy = 0.0
-sun.vz = 0.0
-sun.mass = SOLAR_MASS
-jupiter.x = 4.84143144246472090e+00
-jupiter.y = -1.16032004402742839e+00
-jupiter.z = -1.03622044471123109e-01
-jupiter.vx = 1.66007664274403694e-03 * DAYS_PER_YEAR
-jupiter.vy = 7.69901118419740425e-03 * DAYS_PER_YEAR
-jupiter.vz = -6.90460016972063023e-05 * DAYS_PER_YEAR
-jupiter.mass = 9.54791938424326609e-04 * SOLAR_MASS
-saturn.x = 8.34336671824457987e+00
-saturn.y = 4.12479856412430479e+00
-saturn.z = -4.03523417114321381e-01
-saturn.vx = -2.76742510726862411e-03 * DAYS_PER_YEAR
-saturn.vy = 4.99852801234917238e-03 * DAYS_PER_YEAR
-saturn.vz = 2.30417297573763929e-05 * DAYS_PER_YEAR
-saturn.mass = 2.85885980666130812e-04 * SOLAR_MASS
-uranus.x = 1.28943695621391310e+01
-uranus.y = -1.51111514016986312e+01
-uranus.z = -2.23307578892655734e-01
-uranus.vx = 2.96460137564761618e-03 * DAYS_PER_YEAR
-uranus.vy = 2.37847173959480950e-03 * DAYS_PER_YEAR
-uranus.vz = -2.96589568540237556e-05 * DAYS_PER_YEAR
-uranus.mass = 4.36624404335156298e-05 * SOLAR_MASS
-neptune.x = 1.53796971148509165e+01
-neptune.y = -2.59193146099879641e+01
-neptune.z = 1.79258772950371181e-01
-neptune.vx = 2.68067772490389322e-03 * DAYS_PER_YEAR
-neptune.vy = 1.62824170038242295e-03 * DAYS_PER_YEAR
-neptune.vz = -9.51592254519715870e-05 * DAYS_PER_YEAR
-neptune.mass = 5.15138902046611451e-05 * SOLAR_MASS
 
-local bodies = {sun,jupiter,saturn,uranus,neptune}
+function setup_state()
+  -- defines global variables, that get mutated.
+  sun.x = 0.0
+  sun.y = 0.0
+  sun.z = 0.0
+  sun.vx = 0.0
+  sun.vy = 0.0
+  sun.vz = 0.0
+  sun.mass = SOLAR_MASS
+  jupiter.x = 4.84143144246472090e+00
+  jupiter.y = -1.16032004402742839e+00
+  jupiter.z = -1.03622044471123109e-01
+  jupiter.vx = 1.66007664274403694e-03 * DAYS_PER_YEAR
+  jupiter.vy = 7.69901118419740425e-03 * DAYS_PER_YEAR
+  jupiter.vz = -6.90460016972063023e-05 * DAYS_PER_YEAR
+  jupiter.mass = 9.54791938424326609e-04 * SOLAR_MASS
+  saturn.x = 8.34336671824457987e+00
+  saturn.y = 4.12479856412430479e+00
+  saturn.z = -4.03523417114321381e-01
+  saturn.vx = -2.76742510726862411e-03 * DAYS_PER_YEAR
+  saturn.vy = 4.99852801234917238e-03 * DAYS_PER_YEAR
+  saturn.vz = 2.30417297573763929e-05 * DAYS_PER_YEAR
+  saturn.mass = 2.85885980666130812e-04 * SOLAR_MASS
+  uranus.x = 1.28943695621391310e+01
+  uranus.y = -1.51111514016986312e+01
+  uranus.z = -2.23307578892655734e-01
+  uranus.vx = 2.96460137564761618e-03 * DAYS_PER_YEAR
+  uranus.vy = 2.37847173959480950e-03 * DAYS_PER_YEAR
+  uranus.vz = -2.96589568540237556e-05 * DAYS_PER_YEAR
+  uranus.mass = 4.36624404335156298e-05 * SOLAR_MASS
+  neptune.x = 1.53796971148509165e+01
+  neptune.y = -2.59193146099879641e+01
+  neptune.z = 1.79258772950371181e-01
+  neptune.vx = 2.68067772490389322e-03 * DAYS_PER_YEAR
+  neptune.vy = 1.62824170038242295e-03 * DAYS_PER_YEAR
+  neptune.vz = -9.51592254519715870e-05 * DAYS_PER_YEAR
+  neptune.mass = 5.15138902046611451e-05 * SOLAR_MASS
+
+  bodies = {sun,jupiter,saturn,uranus,neptune}
+end
 
 local function advance(bodies, nbody, dt)
   for i=1,nbody do
@@ -112,14 +120,24 @@ local function offsetMomentum(b, nbody)
   b[1].vz = -pz / SOLAR_MASS
 end
 
-function run_iter(N)
-  --local N = tonumber(arg and arg[1]) or 1000
+local function inner_iter(N)
+  local checksum = 0
+  setup_state()
   local nbody = #bodies
 
   offsetMomentum(bodies, nbody)
-  --io.write( string.format("%0.9f",energy(bodies, nbody)), "\n")
-  string.format("%0.9f",energy(bodies, nbody))
+  checksum = checksum + energy(bodies, nbody)
   for i=1,N do advance(bodies, nbody, 0.01) end
-  --io.write( string.format("%0.9f",energy(bodies, nbody)), "\n")
-  string.format("%0.9f",energy(bodies, nbody))
+  checksum = checksum + energy(bodies, nbody)
+
+  if math.abs(checksum - EXPECT_CHECKSUM) >= EPSILON then
+    print("bad checksum: " .. checksum .. " vs " .. EXPECT_CHECKSUM)
+    os.exit(1)
+  end
+end
+
+function run_iter(n)
+  for i=1, n do
+    inner_iter(N_ADVANCES)
+  end
 end

--- a/benchmarks/nbody/python/bench.py
+++ b/benchmarks/nbody/python/bench.py
@@ -20,7 +20,7 @@ def combinations(l):
             result.append((l[x],y))
     return result
 
-PI = 3.14159265358979323
+PI = 3.141592653589793
 SOLAR_MASS = 4 * PI * PI
 DAYS_PER_YEAR = 365.24
 

--- a/benchmarks/nbody/python/bench.py
+++ b/benchmarks/nbody/python/bench.py
@@ -7,6 +7,11 @@
 
 import sys 
 
+EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625
+N_ADVANCES = 100000
+EPSILON = 0.0000000000001
+
+
 def combinations(l):
     result = []
     for x in xrange(len(l) - 1):
@@ -19,47 +24,51 @@ PI = 3.14159265358979323
 SOLAR_MASS = 4 * PI * PI
 DAYS_PER_YEAR = 365.24
 
-BODIES = {
-    'sun': ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0], SOLAR_MASS),
+def setup_state():
 
-    'jupiter': ([4.84143144246472090e+00,
-                 -1.16032004402742839e+00,
-                 -1.03622044471123109e-01],
-                [1.66007664274403694e-03 * DAYS_PER_YEAR,
-                 7.69901118419740425e-03 * DAYS_PER_YEAR,
-                 -6.90460016972063023e-05 * DAYS_PER_YEAR],
-                9.54791938424326609e-04 * SOLAR_MASS),
+    bodies = {
+        'sun': ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0], SOLAR_MASS),
 
-    'saturn': ([8.34336671824457987e+00,
-                4.12479856412430479e+00,
-                -4.03523417114321381e-01],
-               [-2.76742510726862411e-03 * DAYS_PER_YEAR,
-                4.99852801234917238e-03 * DAYS_PER_YEAR,
-                2.30417297573763929e-05 * DAYS_PER_YEAR],
-               2.85885980666130812e-04 * SOLAR_MASS),
+        'jupiter': ([4.84143144246472090e+00,
+                     -1.16032004402742839e+00,
+                     -1.03622044471123109e-01],
+                    [1.66007664274403694e-03 * DAYS_PER_YEAR,
+                     7.69901118419740425e-03 * DAYS_PER_YEAR,
+                     -6.90460016972063023e-05 * DAYS_PER_YEAR],
+                    9.54791938424326609e-04 * SOLAR_MASS),
 
-    'uranus': ([1.28943695621391310e+01,
-                -1.51111514016986312e+01,
-                -2.23307578892655734e-01],
-               [2.96460137564761618e-03 * DAYS_PER_YEAR,
-                2.37847173959480950e-03 * DAYS_PER_YEAR,
-                -2.96589568540237556e-05 * DAYS_PER_YEAR],
-               4.36624404335156298e-05 * SOLAR_MASS),
+        'saturn': ([8.34336671824457987e+00,
+                    4.12479856412430479e+00,
+                    -4.03523417114321381e-01],
+                   [-2.76742510726862411e-03 * DAYS_PER_YEAR,
+                    4.99852801234917238e-03 * DAYS_PER_YEAR,
+                    2.30417297573763929e-05 * DAYS_PER_YEAR],
+                   2.85885980666130812e-04 * SOLAR_MASS),
 
-    'neptune': ([1.53796971148509165e+01,
-                 -2.59193146099879641e+01,
-                 1.79258772950371181e-01],
-                [2.68067772490389322e-03 * DAYS_PER_YEAR,
-                 1.62824170038242295e-03 * DAYS_PER_YEAR,
-                 -9.51592254519715870e-05 * DAYS_PER_YEAR],
-                5.15138902046611451e-05 * SOLAR_MASS) }
+        'uranus': ([1.28943695621391310e+01,
+                    -1.51111514016986312e+01,
+                    -2.23307578892655734e-01],
+                   [2.96460137564761618e-03 * DAYS_PER_YEAR,
+                    2.37847173959480950e-03 * DAYS_PER_YEAR,
+                    -2.96589568540237556e-05 * DAYS_PER_YEAR],
+                   4.36624404335156298e-05 * SOLAR_MASS),
 
-
-SYSTEM = BODIES.values()
-PAIRS = combinations(SYSTEM)
+        'neptune': ([1.53796971148509165e+01,
+                     -2.59193146099879641e+01,
+                     1.79258772950371181e-01],
+                    [2.68067772490389322e-03 * DAYS_PER_YEAR,
+                     1.62824170038242295e-03 * DAYS_PER_YEAR,
+                     -9.51592254519715870e-05 * DAYS_PER_YEAR],
+                    5.15138902046611451e-05 * SOLAR_MASS) }
 
 
-def advance(dt, n, bodies=SYSTEM, pairs=PAIRS):
+    system = bodies.values()
+    pairs = combinations(system)
+
+    return system, bodies, pairs
+
+
+def advance(dt, n, bodies, pairs):
 
     for i in xrange(n):
         for (([x1, y1, z1], v1, m1),
@@ -82,7 +91,7 @@ def advance(dt, n, bodies=SYSTEM, pairs=PAIRS):
             r[2] += dt * vz
 
 
-def report_energy(bodies=SYSTEM, pairs=PAIRS, e=0.0):
+def report_energy(bodies, pairs, e=0.0):
 
     for (((x1, y1, z1), v1, m1),
          ((x2, y2, z2), v2, m2)) in pairs:
@@ -92,10 +101,9 @@ def report_energy(bodies=SYSTEM, pairs=PAIRS, e=0.0):
         e -= (m1 * m2) / ((dx * dx + dy * dy + dz * dz) ** 0.5)
     for (r, [vx, vy, vz], m) in bodies:
         e += m * (vx * vx + vy * vy + vz * vz) / 2.
-    #print "%.9f" % e
-    "%.9f" % e
+    return e
 
-def offset_momentum(ref, bodies=SYSTEM, px=0.0, py=0.0, pz=0.0):
+def offset_momentum(ref, bodies, px=0.0, py=0.0, pz=0.0):
 
     for (r, [vx, vy, vz], m) in bodies:
         px -= vx * m
@@ -106,8 +114,19 @@ def offset_momentum(ref, bodies=SYSTEM, px=0.0, py=0.0, pz=0.0):
     v[1] = py / m
     v[2] = pz / m
 
-def run_iter(n, ref='sun'):
-    offset_momentum(BODIES[ref])
-    report_energy()
-    advance(0.01, n)
-    report_energy()
+def inner_iter(n, ref='sun'):
+    checksum = 0
+    system, bodies, pairs = setup_state()
+
+    offset_momentum(bodies[ref], system)
+    checksum += report_energy(system, pairs)
+    advance(0.01, n, system, pairs)
+    checksum += report_energy(system, pairs)
+
+    if abs(checksum - EXPECT_CHECKSUM) >= EPSILON:
+        print("bad checksum: %f vs %f" % (checksum, EXPECT_CHECKSUM))
+        sys.exit(1)
+
+def run_iter(n):
+    for i in xrange(n):
+        inner_iter(N_ADVANCES)

--- a/benchmarks/nbody/ruby/bench.rb
+++ b/benchmarks/nbody/ruby/bench.rb
@@ -5,7 +5,8 @@
 # From version ported by Michael Neumann from the C gcc version, 
 # which was written by Christoph Bauer. 
 
-SOLAR_MASS = 4 * Math::PI**2
+PI = 3.141592653589793
+SOLAR_MASS = 4 * PI**2
 DAYS_PER_YEAR = 365.24
 
 @EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625

--- a/benchmarks/nbody/ruby/bench.rb
+++ b/benchmarks/nbody/ruby/bench.rb
@@ -8,6 +8,10 @@
 SOLAR_MASS = 4 * Math::PI**2
 DAYS_PER_YEAR = 365.24
 
+@EXPECT_CHECKSUM = -0.3381550232201908645635057837353087961673736572265625
+@N_ADVANCES = 100000
+@EPSILON = 0.0000000000001
+
 class Planet
  attr_accessor :x, :y, :z, :vx, :vy, :vz, :mass
 
@@ -78,72 +82,84 @@ def offset_momentum(bodies)
   b.vz = - pz / SOLAR_MASS
 end
 
-BODIES = [
-  # sun
-  Planet.new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0),
 
-  # jupiter
-  Planet.new(
-    4.84143144246472090e+00,
-    -1.16032004402742839e+00,
-    -1.03622044471123109e-01,
-    1.66007664274403694e-03,
-    7.69901118419740425e-03,
-    -6.90460016972063023e-05,
-    9.54791938424326609e-04),
+def setup_state()
+    bodies = [
+      # sun
+      Planet.new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0),
 
-  # saturn
-  Planet.new(
-    8.34336671824457987e+00,
-    4.12479856412430479e+00,
-    -4.03523417114321381e-01,
-    -2.76742510726862411e-03,
-    4.99852801234917238e-03,
-    2.30417297573763929e-05,
-    2.85885980666130812e-04),
+      # jupiter
+      Planet.new(
+        4.84143144246472090e+00,
+        -1.16032004402742839e+00,
+        -1.03622044471123109e-01,
+        1.66007664274403694e-03,
+        7.69901118419740425e-03,
+        -6.90460016972063023e-05,
+        9.54791938424326609e-04),
 
-  # uranus
-  Planet.new(
-    1.28943695621391310e+01,
-    -1.51111514016986312e+01,
-    -2.23307578892655734e-01,
-    2.96460137564761618e-03,
-    2.37847173959480950e-03,
-    -2.96589568540237556e-05,
-    4.36624404335156298e-05),
+      # saturn
+      Planet.new(
+        8.34336671824457987e+00,
+        4.12479856412430479e+00,
+        -4.03523417114321381e-01,
+        -2.76742510726862411e-03,
+        4.99852801234917238e-03,
+        2.30417297573763929e-05,
+        2.85885980666130812e-04),
 
-  # neptune
-  Planet.new(
-    1.53796971148509165e+01,
-    -2.59193146099879641e+01,
-    1.79258772950371181e-01,
-    2.68067772490389322e-03,
-    1.62824170038242295e-03,
-    -9.51592254519715870e-05,
-    5.15138902046611451e-05)
-]
+      # uranus
+      Planet.new(
+        1.28943695621391310e+01,
+        -1.51111514016986312e+01,
+        -2.23307578892655734e-01,
+        2.96460137564761618e-03,
+        2.37847173959480950e-03,
+        -2.96589568540237556e-05,
+        4.36624404335156298e-05),
 
+      # neptune
+      Planet.new(
+        1.53796971148509165e+01,
+        -2.59193146099879641e+01,
+        1.79258772950371181e-01,
+        2.68067772490389322e-03,
+        1.62824170038242295e-03,
+        -9.51592254519715870e-05,
+        5.15138902046611451e-05)
+    ]
+end
 
-def run_iter(n)
-    #n = Integer(ARGV[0])
+def inner_iter(n)
+    bodies = setup_state()
+    checksum = 0
 
-    offset_momentum(BODIES)
+    offset_momentum(bodies)
 
-    #puts "%.9f" % energy(BODIES)
-    "%.9f" % energy(BODIES)
+    checksum += energy(bodies)
 
-    nbodies = BODIES.size
+    nbodies = bodies.size
     dt = 0.01
 
     n.times do
       i = 0
       while i < nbodies
-        b = BODIES[i]
-        b.move_from_i(BODIES, nbodies, dt, i + 1)
+        b = bodies[i]
+        b.move_from_i(bodies, nbodies, dt, i + 1)
         i += 1
       end
     end
 
-    #puts "%.9f" % energy(BODIES)
-    "%.9f" % energy(BODIES)
+    checksum += energy(bodies)
+
+    if (checksum - @EXPECT_CHECKSUM).abs >= @EPSILON then
+        puts("bad checksum: %f vs %f" % [checksum, @EXPECT_CHECKSUM])
+        exit(1)
+    end
+end
+
+def run_iter(n)
+  for i in 1..n do
+    inner_iter(@N_ADVANCES)
+  end
 end


### PR DESCRIPTION
Checksums for nbody.

Uses a epsilon tolerance, as the double operations vary between languages. Not ideal, but the best we have.

Please check carefully. Some benchmarks were still mutating global state, and thus some of the benchmarks were changed a fair amount to cater with this.

OK?
