### PR TITLE
Btrees checksums

### DIFF
--- a/benchmarks/binarytrees/c/bench.c
+++ b/benchmarks/binarytrees/c/bench.c
@@ -15,9 +15,7 @@
 
 #define MIN_DEPTH 4
 #define MAX_DEPTH 12
-#define EXPECT_CKSUM 4294956382
-
-static u_int32_t checksum = 0;
+#define EXPECT_CKSUM -10914
 
 typedef struct tn {
     struct tn*    left;
@@ -80,11 +78,12 @@ int inner_rep(int minDepth, int maxDepth)
 {
     unsigned   depth, stretchDepth;
     treeNode   *stretchTree, *longLivedTree, *tempTree;
+    int32_t	check = 0;
 
     stretchDepth = maxDepth + 1;
 
     stretchTree = BottomUpTree(0, stretchDepth);
-    checksum += ItemCheck(stretchTree);
+    check += ItemCheck(stretchTree);
 
     DeleteTree(stretchTree);
 
@@ -92,11 +91,9 @@ int inner_rep(int minDepth, int maxDepth)
 
     for (depth = minDepth; depth <= maxDepth; depth += 2)
     {
-        long    i, iterations, check;
+        long    i, iterations;
 
         iterations = pow(2, maxDepth - depth + minDepth);
-
-        check = 0;
 
         for (i = 1; i <= iterations; i++)
         {
@@ -109,15 +106,13 @@ int inner_rep(int minDepth, int maxDepth)
             DeleteTree(tempTree);
         } /* for(i = 1...) */
 
-        checksum += check;
-
     } /* for(depth = minDepth...) */
 
-    checksum += ItemCheck(longLivedTree);
+    check += ItemCheck(longLivedTree);
     DeleteTree(longLivedTree);
 
-    if (checksum != EXPECT_CKSUM) {
-        errx(EXIT_FAILURE, "checksum failed: %u vs %lu", checksum, EXPECT_CKSUM);
+    if (check != EXPECT_CKSUM) {
+        errx(EXIT_FAILURE, "checksum failed: %u vs %lu", check, EXPECT_CKSUM);
     }
 
     return 0;
@@ -128,6 +123,5 @@ void run_iter(int n) {
 
     for (i = 0; i < n; i++) {
         inner_rep(MIN_DEPTH, MAX_DEPTH);
-        checksum = 0;
     }
 }

--- a/benchmarks/binarytrees/java/binarytrees.java
+++ b/benchmarks/binarytrees/java/binarytrees.java
@@ -1,53 +1,60 @@
 /* The Great Computer Language Shootout
    http://shootout.alioth.debian.org/
- 
+
    contributed by Jarkko Miettinen
 */
 
 public class binarytrees {
     static void init() {};
 
-	private final static int minDepth = 4;
-	
-	public static void main(String[] args){
-		int n = 0;
-		if (args.length > 0) n = Integer.parseInt(args[0]);
-        binarytrees.run(n);
-    }
+	private static final int MIN_DEPTH = 4;
+	private static final int MAX_DEPTH = 12;
+	private static final long EXPECT_CKSUM = -10914;
+	private static long MOD;
+	private static int check = 0;
 
-    public static void run(int n) {
-		
-		int maxDepth = (minDepth + 2 > n) ? minDepth + 2 : n;
+
+	public static void run(int n) {
+		for (int i = 0; i < n; i++) {
+			check = 0;
+			inner_iter(MIN_DEPTH, MAX_DEPTH);
+		}
+	}
+
+	public static void inner_iter(int minDepth, int maxDepth) {
 		int stretchDepth = maxDepth + 1;
-		
-		int check = (TreeNode.bottomUpTree(0,stretchDepth)).itemCheck();
-		//System.out.println("stretch tree of depth "+stretchDepth+"\t check: " + check);
-		
+
+		check += TreeNode.bottomUpTree(0,stretchDepth).itemCheck();
+
 		TreeNode longLivedTree = TreeNode.bottomUpTree(0,maxDepth);
-		
+
 		for (int depth=minDepth; depth<=maxDepth; depth+=2){
 			int iterations = 1 << (maxDepth - depth + minDepth);
-			check = 0;
-			
+
 			for (int i=1; i<=iterations; i++){
 				check += (TreeNode.bottomUpTree(i,depth)).itemCheck();
 				check += (TreeNode.bottomUpTree(-i,depth)).itemCheck();
 			}
-			//System.out.println((iterations*2) + "\t trees of depth " + depth + "\t check: " + check);
-		}	
-		//System.out.println("long lived tree of depth " + maxDepth + "\t check: "+ longLivedTree.itemCheck());
+		}
+
+		check += longLivedTree.itemCheck();
+
+		if (check != EXPECT_CKSUM) {
+			System.out.println("bad check: " + check  + " vs " + EXPECT_CKSUM);
+			System.exit(1);
+		}
 	}
-	
-	
+
+
 	private static class TreeNode
 	{
 		private TreeNode left, right;
 		private int item;
-		
+
 		TreeNode(int item){
 			this.item = item;
 		}
-		
+
 		private static TreeNode bottomUpTree(int item, int depth){
 			if (depth>0){
 				return new TreeNode(
@@ -60,13 +67,13 @@ public class binarytrees {
 				return new TreeNode(item);
 			}
 		}
-		
+
 		TreeNode(TreeNode left, TreeNode right, int item){
 			this.left = left;
 			this.right = right;
 			this.item = item;
 		}
-		
+
 		private int itemCheck(){
 			// if necessary deallocate here
 			if (left==null) return item;

--- a/benchmarks/binarytrees/javascript/bench.js
+++ b/benchmarks/binarytrees/javascript/bench.js
@@ -2,6 +2,10 @@
    http://benchmarksgame.alioth.debian.org/
    contributed by Isaac Gouy */
 
+var MIN_DEPTH = 4;
+var MAX_DEPTH = 12;
+var EXPECT_CKSUM = -10914
+
 function TreeNode(left,right,item){
    this.left = left;
    this.right = right;
@@ -27,27 +31,33 @@ function bottomUpTree(item,depth){
 }
 
 
-function run_iter(n) {
-    var minDepth = 4;
-    //var n = arguments[0];
-    var maxDepth = Math.max(minDepth + 2, n);
+function inner_iter(minDepth, maxDepth) {
+    var check = 0;
     var stretchDepth = maxDepth + 1;
 
-    var check = bottomUpTree(0,stretchDepth).itemCheck();
-    //print("stretch tree of depth " + stretchDepth + "\t check: " + check);
+    check = bottomUpTree(0,stretchDepth).itemCheck();
 
     var longLivedTree = bottomUpTree(0,maxDepth);
     for (var depth=minDepth; depth<=maxDepth; depth+=2){
        var iterations = 1 << (maxDepth - depth + minDepth);
 
-       check = 0;
        for (var i=1; i<=iterations; i++){
           check += bottomUpTree(i,depth).itemCheck();
           check += bottomUpTree(-i,depth).itemCheck();
        }
-       //print(iterations*2 + "\t trees of depth " + depth + "\t check: " + check);
     }
 
-    //print("long lived tree of depth " + maxDepth + "\t check: " 
-    //   + longLivedTree.itemCheck());
+    check += longLivedTree.itemCheck();
+
+    if (check != EXPECT_CKSUM) {
+        print("bad checksum: " + checksum + " vs " + EXPECT_CKSUM);
+        quit(1);
+    }
+}
+
+function run_iter(n) {
+    var i;
+    for (i = 0; i < n; i++) {
+        inner_iter(MIN_DEPTH, MAX_DEPTH);
+    }
 }

--- a/benchmarks/binarytrees/php/bench.php
+++ b/benchmarks/binarytrees/php/bench.php
@@ -7,6 +7,10 @@
    modified by Craig Russell
  */
 
+define("MIN_DEPTH", 4);
+define("MAX_DEPTH", 12);
+define("EXPECT_CKSUM", -10914);
+
 class Tree {
    public $i;
    public $l;
@@ -28,16 +32,12 @@ class Tree {
 }
 
 
-function run_iter($n) {
-    $minDepth = 4;
-
-    //$n = $argc == 2 ? $argv[1] : 1;
-    $maxDepth = $minDepth + 2 > $n ? $minDepth + 2 : $n;
+function inner_iter($minDepth, $maxDepth) {
+    $check = 0;
     $stretchDepth = $maxDepth + 1;
 
     $stretch = new Tree(0, $stretchDepth);
-    //printf("stretch tree of depth %d\t check: %d\n",
-    //   $stretchDepth, $stretch->check());
+    $check += $stretch->check();
     unset($stretch);
 
     $longLivedTree = new Tree(0, $maxDepth);
@@ -45,22 +45,28 @@ function run_iter($n) {
     $iterations = 1 << $maxDepth;
     do
     {
-       $check = 0;
        for($i = 1; $i <= $iterations; ++$i)
        {
           $check += (new Tree($i, $minDepth))->check()
              + (new Tree(-$i, $minDepth))->check();
        }
 
-       //printf("%d\t trees of depth %d\t check: %d\n",
-       //   $iterations<<1, $minDepth, $check);
-
        $minDepth += 2;
        $iterations >>= 2;
     }
     while($minDepth <= $maxDepth);
 
-    //printf("long lived tree of depth %d\t check: %d\n",
-    //   $maxDepth, $longLivedTree->check());
+    $check += $longLivedTree->check();
+
+    if ($check != EXPECT_CKSUM) {
+        echo "bad checksum: " . $check . " vs " . EXPECT_CKSUM . "\n";
+        exit(1);
+    }
+}
+
+function run_iter($n) {
+    for ($i = 0; $i < $n; $i++) {
+        inner_iter(MIN_DEPTH, MAX_DEPTH);
+    }
 }
 ?>

--- a/benchmarks/binarytrees/python/bench.py
+++ b/benchmarks/binarytrees/python/bench.py
@@ -5,6 +5,10 @@
 # modified by Dominique Wahli
 # modified by Heinrich Acker
 
+MIN_DEPTH = 4
+MAX_DEPTH = 12
+EXPECT_CKSUM = -10914
+
 import sys
 
 class Tree(object):
@@ -24,23 +28,30 @@ def check_tree(tree):
     if not isinstance(tree, Tree): return tree
     return tree.item + check_tree(tree.left) - check_tree(tree.right)
 
-def run_iter(n):
-    min_depth = 4
-    max_depth = max(min_depth + 2, n)
+
+def inner_iter(min_depth, max_depth):
+    checksum = 0
     stretch_depth = max_depth + 1
 
-    #print "stretch tree of depth %d\t check:" % stretch_depth, check_tree(make_tree(0, stretch_depth))
+    checksum += check_tree(make_tree(0, stretch_depth))
 
     long_lived_tree = make_tree(0, max_depth)
 
     iterations = 2**max_depth
     for depth in xrange(min_depth, stretch_depth, 2):
 
-        check = 0
         for i in xrange(1, iterations + 1):
-            check += check_tree(make_tree(i, depth)) + check_tree(make_tree(-i, depth))
+            checksum += check_tree(make_tree(i, depth)) + check_tree(make_tree(-i, depth))
 
-        #print "%d\t trees of depth %d\t check:" % (iterations * 2, depth), check
         iterations /= 4
 
-    #print "long lived tree of depth %d\t check:" % max_depth, check_tree(long_lived_tree)
+    checksum += check_tree(long_lived_tree)
+
+    if checksum != EXPECT_CKSUM:
+        print("bad checksum: %d vs %d" % (checksum, EXPECT_CKSUM))
+        sys.exit(1)
+
+
+def run_iter(n):
+    for i in xrange(n):
+        inner_iter(MIN_DEPTH, MAX_DEPTH)

--- a/benchmarks/binarytrees/ruby/bench.rb
+++ b/benchmarks/binarytrees/ruby/bench.rb
@@ -4,6 +4,9 @@
 # contributed by Jesse Millikan
 # Modified by Wesley Moxam and Michael Klaus
 
+@MIN_DEPTH = 4
+@MAX_DEPTH = 12
+@EXPECT_CKSUM = -10914
 
 def item_check(left, item, right)
   return item if left.nil?
@@ -17,16 +20,12 @@ def bottom_up_tree(item, depth)
   [bottom_up_tree(item_item - 1, depth), item, bottom_up_tree(item_item, depth)]
 end
 
-def run_iter(max_depth)
-    #max_depth = ARGV[0].to_i
-    min_depth = 4
-
-    max_depth = [min_depth + 2, max_depth].max
-
+def inner_iter(min_depth, max_depth)
+    check = 0
     stretch_depth = max_depth + 1
     stretch_tree = bottom_up_tree(0, stretch_depth)
 
-    #puts "stretch tree of depth #{stretch_depth}\t check: #{item_check(*stretch_tree)}"
+    check += item_check(*stretch_tree)
     stretch_tree = nil
 
     long_lived_tree = bottom_up_tree(0, max_depth)
@@ -34,9 +33,6 @@ def run_iter(max_depth)
     base_depth = max_depth + min_depth
     min_depth.step(max_depth + 1, 2) do |depth|
       iterations = 2 ** (base_depth - depth)
-
-      check = 0
-
       for i in 1..iterations
         temp_tree = bottom_up_tree(i, depth)
         check += item_check(*temp_tree)
@@ -44,9 +40,18 @@ def run_iter(max_depth)
         temp_tree = bottom_up_tree(-i, depth)
         check += item_check(*temp_tree)
       end
-
-      #puts "#{iterations * 2}\t trees of depth #{depth}\t check: #{check}"
     end
 
-    #puts "long lived tree of depth #{max_depth}\t check: #{item_check(*long_lived_tree)}"
+    check += item_check(*long_lived_tree)
+
+    if check != @EXPECT_CKSUM then
+        puts("bad checksum: %d vs %d" % [check, @EXPECT_CKSUM])
+        exit(1)
+    end
+end
+
+def run_iter(n)
+    for i in 1..n do
+        inner_iter(@MIN_DEPTH, @MAX_DEPTH)
+    end
 end


### PR DESCRIPTION
Checksums for btrees benchmarks.

You may recall I said that this benchmark makes huge checksums. It does not, my unsigned integer was underflowing. I've instead used a signed integer and I've checked that there are no over/underflow situations by (temporarily) replacing `+` and `-` on checksums with `Math.{add,subtract}Exact()` in Java. No exceptions were raised, therefore we have no over/underflows. These checks have now been removed.

Note that the original benchmark created three (unchecked) checksums. I make a single checksum by summing all three.

OK?
