### PR TITLE
Fix the mx version for graal.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -251,6 +251,7 @@ build_jdk() {
 }
 
 MX_REPO=https://bitbucket.org/allr/mx
+MX_VERSION=d94328febb37
 GRAAL_REPO=http://hg.openjdk.java.net/graal/graal-compiler
 GRAAL_VERSION=9dafd1dc5ff9
 # Building with the JDK we built earlier is troublesome (SSL+maven issues).
@@ -264,7 +265,7 @@ build_graal() {
 	echo "\n===> Download and build graal\n"
 
 	if [ ! -d ${wrkdir}/mx ]; then
-		cd ${wrkdir} && hg clone ${MX_REPO} || exit $?
+		cd ${wrkdir} && hg clone -r ${MX_VERSION} ${MX_REPO} || exit $?
 	fi
 
 	if [ -f ${wrkdir}/jvmci/jdk1.8.0-internal/product/bin/javac ]; then return; fi


### PR DESCRIPTION
This fixes the mx version we use to that of the graal version we use. The build now passes on bencher5.

I'm not sure why bencher3 built graal without this, whereas bencher5 failed. I'm going to re-run the build again to check that the failure isn't non-deterministic.

Either way, we certainly should fix the mx version we use.

[As you can see we have already gone through similar problems to our v8 problen with graal and mx (expand the lines just under the changes)]
