### PR TITLE
Use our own GCC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,16 @@ ifeq (${UNAME}, Linux)
 	JAVA_HOME = ${PWD}/work/openjdk/build/linux-x86_64-normal-server-release/images/j2sdk-image
 	JAVAC = ${PWD}/work/openjdk/build/linux-x86_64-normal-server-release/jdk/bin/javac
 	JAVA_INC = ${JAVA_HOME}/include/linux
+	GCC_LIB_DIR = ${PWD}/work/gcc-inst/lib64
 endif
 ifeq (${UNAME}, OpenBSD)
 	JAVA_HOME = ${PWD}/work/openjdk/build/bsd-x86_64-normal-server-release/images/j2sdk-image
 	JAVAC = ${PWD}/work/openjdk/build/bsd-x86_64-normal-server-release/jdk/bin/javac
 	JAVA_INC = ${JAVA_HOME}/include/openbsd
+	GCC_LIB_DIR = ${PWD}/work/gcc-inst/lib
 endif
 
-# XXX build our on GCC and plug in
-CC = cc
+CC=${PWD}/work/gcc-inst/bin/zgcc
 
 all: build-vms build-benchs build-krun build-startup
 	@echo ""
@@ -30,15 +31,19 @@ build-vms:
 
 build-benchs: build-krun
 	cd benchmarks && \
+		env LD_LIBRARY_PATH=${GCC_LIB_DIR} \
 		${MAKE} CC=${CC} JAVAC=${JAVAC}
 
 build-krun:
-	cd krun && ${MAKE} JAVA_CPPFLAGS='"-I${JAVA_HOME}/include -I${JAVA_INC}"' \
+	cd krun && env LD_LIBRARY_PATH=${GCC_LIB_DIR} ${MAKE} CC=${CC} \
+		JAVA_CPPFLAGS='"-I${JAVA_HOME}/include -I${JAVA_INC}"' \
 		JAVA_LDFLAGS=-L${JAVA_HOME}/lib \
 		JAVAC=${JAVAC} ENABLE_JAVA=1
 
 build-startup: build-krun
-	cd startup_runners && ${MAKE} JAVA_CPPFLAGS='"-I${JAVA_HOME}/include \
+	cd startup_runners && \
+		env LD_LIBRARY_PATH=${GCC_LIB_DIR} ${MAKE} CC=${CC} \
+		${MAKE} JAVA_CPPFLAGS='"-I${JAVA_HOME}/include \
 		-I${JAVA_HOME}/include/linux"' \
 		JAVA_LDFLAGS=-L${JAVA_HOME}/lib \
 		JAVAC=${JAVAC} ENABLE_JAVA=1

--- a/warmup.krun
+++ b/warmup.krun
@@ -6,23 +6,29 @@ from krun.vm_defs import (PythonVMDef, LuaVMDef, JavaVMDef, GraalVMDef,
 from krun import EntryPoint
 
 # Who to mail
-MAIL_TO = ["vext01@gmail.com", "mount.sarah@gmail.com"]
-
-# Maximum number of error emails to send per-run
-#MAX_MAILS = 2
+MAIL_TO = []
 
 DIR = os.getcwd()
 JKRUNTIME_DIR = os.path.join(DIR, "krun", "libkruntime", "")
 
-if not sys.platform.startswith("openbsd"):
+if sys.platform.startswith("linux"):
     JDK8_HOME = os.path.join(DIR, "work/openjdk/build/linux-x86_64-normal-server-release/images/j2sdk-image/")
-else:
+elif sys.platform.startswith("openbsd"):
     JDK8_HOME = os.path.join(DIR, "work/openjdk/build/bsd-x86_64-normal-server-release/images/j2sdk-image/")
+else:
+    raise NotImplementedError("unknown platform")
 
 JDK8_BIN = os.path.join(JDK8_HOME, "bin", "java")
 
-HEAP_LIMIT = 2097152  # K == 2Gb
-STACK_LIMIT = 8192  # K
+if sys.platform.startswith("linux"):
+    GCC_ENV = {"LD_LIBRARY_PATH": os.path.join(DIR, "work/gcc-inst/lib64")}
+elif sys.platform.startswith("openbsd"):
+    GCC_ENV = {"LD_LIBRARY_PATH": os.path.join(DIR, "work/gcc-inst/lib")}
+else:
+    raise NotImplementedError("unknown platform")
+
+HEAP_LIMIT = 2097152  # 2GiB
+STACK_LIMIT = 8192  # 8 MiB
 
 # Variant name -> EntryPoint
 VARIANTS = {
@@ -39,33 +45,35 @@ ITERATIONS_ALL_VMS = 2000
 
 VMS = {
         'C': {
-		'vm_def': NativeCodeVMDef(),
+		'vm_def': NativeCodeVMDef(env=GCC_ENV),
 		'variants': ['default-c'],
 		'n_iterations': ITERATIONS_ALL_VMS,
 
         },
 	'PyPy': {
-		'vm_def': PyPyVMDef('work/pypy/pypy/goal/pypy-c'),
+		'vm_def': PyPyVMDef('work/pypy/pypy/goal/pypy-c',
+                      env=GCC_ENV),
 		'variants': ['default-python'],
 		'n_iterations': ITERATIONS_ALL_VMS,
 	},
 	'Hotspot': {
-		'vm_def': JavaVMDef(JDK8_BIN),
+		'vm_def': JavaVMDef(JDK8_BIN, env=GCC_ENV),
 		'variants': ['default-java'],
 		'n_iterations': ITERATIONS_ALL_VMS,
 	},
 	'LuaJIT': {
-		'vm_def': LuaVMDef('work/luajit/src/luajit'),
+		'vm_def': LuaVMDef('work/luajit/src/luajit', env=GCC_ENV),
 		'variants': ['default-lua'],
 		'n_iterations': ITERATIONS_ALL_VMS,
 	},
 	'V8': {
-		'vm_def': V8VMDef('work/v8/out/native/d8'),
+		'vm_def': V8VMDef('work/v8/out/native/d8', env=GCC_ENV),
 		'variants': ['default-javascript'],
 		'n_iterations': ITERATIONS_ALL_VMS,
 	},
 	'CPython': {
-		'vm_def': PythonVMDef('work/cpython-inst/bin/python'),
+		'vm_def': PythonVMDef('work/cpython-inst/bin/python',
+                        env=GCC_ENV),
 		'variants': ['default-python'],
 		'n_iterations': ITERATIONS_ALL_VMS,
 	}
@@ -75,18 +83,20 @@ if not sys.platform.startswith("openbsd"):
     # The following VMs do not run on OpenBSD.
     VMS.update({
         'Graal': {
-            'vm_def': GraalVMDef("dummy", JDK8_HOME),
+            'vm_def': GraalVMDef(find_internal_jvmci_java_bin('work/jvmci/'),
+                                 JDK8_HOME, env=GCC_ENV),
             'variants': ['default-java'],
             'n_iterations': ITERATIONS_ALL_VMS,
         },
         'HHVM': {
-            'vm_def': PHPVMDef('work/hhvm/hphp/hhvm/php'),
+            'vm_def': PHPVMDef('work/hhvm/hphp/hhvm/php', env=GCC_ENV),
             'variants': ['default-php'],
             'n_iterations': ITERATIONS_ALL_VMS,
         },
         'JRubyTruffle' : {
             'vm_def': JRubyTruffleVMDef('work/jruby/bin/jruby',
-                                        java_path="dummy"),
+                                        java_path=find_internal_jvmci_java_bin('work/jvmci/'),
+                                        env=GCC_ENV),
             'variants': ['default-ruby'],
             'n_iterations': ITERATIONS_ALL_VMS,
         },


### PR DESCRIPTION
_Alert the media! We have managed to bootstrap GCC-4.9.3 and use it throughout!_

Our gcc is installed as `zgcc` and `zg++`. I was able to get most VMs to use these using environment or make variables. However, it seems a couple of VMs (HHVM and Graal) cannot be swayed. HHVM fails to pass down the correct GCC to Ocaml (for the offline type checker) and Graal has gcc hard-coded (confirmed with Chris Seaton). For these I make temporary symlinks to our `zgcc` and force our bin path first.

The build succeeds on OpenBSD and Linux. During testing, after bootstrapping GCC, I crippled the system compilers (`chmod -x`) before continuing. This confirms that the system GCC isn't being invoked.

Getting GCC bootstrapped on OpenBSD was a challenge. For future reference, here are bug reports relating to this:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69757
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69744

I've also fixed a some bogus stuff that seems to have crept into `warmup.krun`. The "dummy" paths were not supposed to have been pushed into master. Similarly for the `MAIL_TO` lines.

OK?
