### PR TITLE
Since we only want 64 bit binaries, there's no point in supporting 32 bit arches

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -109,6 +109,7 @@ build_gcc() {
         --verbose \
         --disable-libmudflap \
         --disable-libgomp \
+        --disable-multilib \
         --disable-tls \
         --enable-languages=c,c++ \
         --with-system-zlib \


### PR DESCRIPTION
This solves the "I suspect your system does not have 32-bit developement
libraries" message on some Linux boxes.

Warning: currently under testing. Do not merge yet.
