### PR TITLE
Print u_int64_t consistently across platforms.

### DIFF
--- a/benchmarks/fasta/c/bench.c
+++ b/benchmarks/fasta/c/bench.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include <err.h>
 
 typedef struct {
@@ -146,7 +147,7 @@ void run_iter(int n) {
       rand_fasta(homosapiens, SCALE * 5);
 
       if (checksum != EXPECT_CKSUM) {
-         errx(EXIT_FAILURE, "checksum fail: %lu vs %u",
+         errx(EXIT_FAILURE, "checksum fail: %" PRIu64 " vs %u",
 	     checksum, EXPECT_CKSUM);
       }
 


### PR DESCRIPTION
One of the C benchmarks (fasta) emits a warning when printing a unsigned 64. If I (naively) fix this on one platform (e.g. Linux), the other platform (BSD) will start emitting the warning. Seems there's a discrepancy in integer types between the platforms.

This is the correct way to do this.

OK? 
