### PR TITLE
Update OpenJDK version used.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -249,8 +249,7 @@ build_gmake() {
     cp make gmake
 }
 
-JDK_DIST=openjdk-8u45b14-bsd-port-20150618.tar.xz
-JDK_INNER_DIR=openjdk-8u45b14-bsd-port-20150618
+JDK_DIR=openjdk-8u72b15-bsd-port-20160220
 case `uname` in
     Linux)
       JDK_JAVAC=${wrkdir}/openjdk/build/linux-x86_64-normal-server-release/jdk/bin/javac;;
@@ -262,11 +261,11 @@ build_jdk() {
     echo "\n===> Download and build JDK8\n"
     if [ -f ${JDK_JAVAC} ]; then return; fi
     cd ${wrkdir} || exit $?
-    if ! [ -f "${wrkdir}/${JDK_DIST}" ]; then
-        wget http://www.intricatesoftware.com/distfiles/${JDK_DIST} || exit $?
+    if ! [ -f "${wrkdir}/${JDK_DIR}" ]; then
+        wget http://www.intricatesoftware.com/distfiles/${JDK_DIR}.tar.xz || exit $?
     fi
-    xzdec ${JDK_DIST} | tar xf - || exit $?
-    mv ${JDK_INNER_DIR} openjdk
+    xzdec ${JDK_DIR}.tar.xz | tar xf - || exit $?
+    mv ${JDK_DIR} openjdk
     cd openjdk || exit $?
     JDK_BUILD_PATH=`dirname ${OUR_CC}`:${PATH}
     case `uname` in

--- a/build.sh
+++ b/build.sh
@@ -291,21 +291,21 @@ build_jdk() {
             env CPPFLAGS=-I/usr/local/include \
               LDFLAGS=-L/usr/local/lib \
               CC=zgcc CXX=zg++ PATH=${JDK_BUILD_PATH} ac_cv_path_NAWK=awk bash configure \
-	    --disable-option-checking \
-	    --with-cups-include=/usr/local/include \
-	    --with-jobs=8 \
-		    --with-debug-level=release \
-	    --with-debug-level=release \
-	    --disable-ccache \
-	    --disable-freetype-bundling \
-	    --disable-zip-debug-info \
-	    --disable-debug-symbols \
-	    --enable-static-libjli \
-	    --with-zlib=system \
-	    --with-giflib=system \
-	    --with-milestone=fcs \
-	    || exit $?
-	      PATH=${JDK_BUILD_PATH} \
+              --disable-option-checking \
+              --with-cups-include=/usr/local/include \
+              --with-jobs=8 \
+          	    --with-debug-level=release \
+              --with-debug-level=release \
+              --disable-ccache \
+              --disable-freetype-bundling \
+              --disable-zip-debug-info \
+              --disable-debug-symbols \
+              --enable-static-libjli \
+              --with-zlib=system \
+              --with-giflib=system \
+              --with-milestone=fcs \
+	      || exit $?
+	    PATH=${JDK_BUILD_PATH} \
 	    COMPILER_WARNINGS_FATAL=false \
 	    DEFAULT_LIBPATH="/usr/lib:/usr/X11R6/lib:/usr/local/lib"\
 	    ../make-${GMAKE_V}/make all || exit $?

--- a/build.sh
+++ b/build.sh
@@ -89,10 +89,9 @@ build_gcc() {
     fi
     cd gcc || exit $?
 
-    # OpenBSD needs patches
-    if [ `uname` -eq "openbsd" ]; then
-        for i in ../../patches/openbsd_gcc_patches/patch*; do
-            patch -Ep0 < $i || exit $?
+    if [ `uname` = "OpenBSD" ]; then
+        for p in `ls ${PATCH_DIR}/openbsd_gcc_patches`; do
+            patch -Ep0 < ${PATCH_DIR}/openbsd_gcc_patches/$p || exit $?
         done
     fi
 


### PR DESCRIPTION
Build tested on bencher[56].

This also fixes a problem whereby OpenBSD-only GCC patches were applied on Linux (this might have caused the HHVM problems on bencher3?).
