### PR TITLE
Don't build tracing versions of Java benchmarks.

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -24,7 +24,7 @@ java-benchmarks:
 	for i in ${BENCHMARKS}; do \
 		echo "Building java benchmark $${i}..."; \
 		cd ${PWD}/$${i}/java && \
-		CLASSPATH=../../../krun/iterations_runners/ ${JAVAC} *.java; \
+		CLASSPATH=../../../krun/iterations_runners/ ${JAVAC} `ls *.java | grep -v trace`; \
 		done
 
 c-benchmarks:


### PR DESCRIPTION
Let's not build the tracing versions of benchmarks. We don't use them in the experiment proper.

Currently only the Java tracing versions are built. This PR disables building them.

OK?
