### PR TITLE
Pre/post command tweaks

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -145,12 +145,14 @@ N_EXECUTIONS = 10  # Number of fresh processes.
 if sys.platform.startswith("linux"):
     PRE_EXECUTION_CMDS = [
         "sudo service cron stop",
+        "sudo service atd stop",
         "sudo service postfix stop",
     ]
 
     POST_EXECUTION_CMDS = [
-        "sudo service cron start",
-        "sudo service postfix start",
+        "sudo service cron start || true",
+        "sudo service atd start || true",
+        "sudo service postfix start || true",
     ]
 elif sys.platform.startswith("openbsd"):
     PRE_EXECUTION_CMDS = [
@@ -159,16 +161,21 @@ elif sys.platform.startswith("openbsd"):
     ]
 
     POST_EXECUTION_CMDS = [
-        "sudo /etc/rc.d/cron start",
-        "sudo /etc/rc.d/smtpd start",
+        "sudo /etc/rc.d/cron start || true",
+        "sudo /etc/rc.d/smtpd start || true",
     ]
 else:
     assert False
 
 
 # Copy off results after each execution -- soft-dev specific!
+#
+# We allow failure, otherwise Krun will halt the experiment if (e.g.) the
+# SSH server hostname is temporarily unavailable.
 HOSTNAME = platform.node().split(".")[0]
+SCP_CMD = ("tar czf - ${KRUN_RESULTS_FILE} ${KRUN_LOG_FILE} | "
+           "ssh -i id_rsa " "vext01@bencher2.soft-dev.org "
+           "'cat > research/krun_results/%s.tgz'" % HOSTNAME)
 POST_EXECUTION_CMDS.append(
-    "tar czf - ${KRUN_RESULTS_FILE} ${KRUN_LOG_FILE} | "
-    "ssh -i id_rsa " "vext01@bencher2.soft-dev.org "
-    "'cat > research/krun_results/%s.tgz'" % HOSTNAME)
+    "%s || ( sleep 2; %s ) || true " % (SCP_CMD, SCP_CMD)
+)


### PR DESCRIPTION
I just noticed that Linux has another daemon that could run big tasks:  atd. In OpenBSD this is part of cron. One change ensures this is off -- just in case.

Also allow scp to fail as discussed on email.

OK?

CC @cfbolz @snim2 

Related note:

Just found rouge instances of gkrelmd on benchers. For some reason the line for gkrellmd (`service --status-all`) came out of stderr (not stdout) so I missed it when I was inspecting  the running services. I've removed gkrellmd on both benchers.

Looking at top, gkrellmd sometimes zips to the top of the process list, so there's a chance it has had a negative impact. I think we need to re-start the experiment.
