### PR TITLE
Stop pflogd.

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -158,11 +158,13 @@ elif sys.platform.startswith("openbsd"):
     PRE_EXECUTION_CMDS = [
         "sudo /etc/rc.d/cron stop",
         "sudo /etc/rc.d/smtpd stop",
+        "sudo /etc/rc.d/pflogd stop",
     ]
 
     POST_EXECUTION_CMDS = [
         "sudo /etc/rc.d/cron start || true",
         "sudo /etc/rc.d/smtpd start || true",
+        "sudo /etc/rc.d/pflogd start || true",
     ]
 else:
     assert False


### PR DESCRIPTION
`pflogd` is a daemon that runs by default on OpenBSD. Its purpose is to log firewall packets. I don't think this should run during benchmarking. 

OK?
