### PR TITLE
Reenable a no-longer-crashing benchmark (and tidy another)

### DIFF
--- a/benchmarks/fasta/ruby/bench.rb
+++ b/benchmarks/fasta/ruby/bench.rb
@@ -93,9 +93,8 @@ def make_random_fasta(table, n)
 end
 
 
-# work around ruby scoping using lambda
 def run_iter(n)
-    for i in 0..n-1  # inclusive upper bound
+    for i in 0..n-1
         make_repeat_fasta(@alu, @SCALE*2)
         make_random_fasta(@iub, @SCALE*3)
         make_random_fasta(@homosapiens, @SCALE*5)

--- a/benchmarks/fasta/ruby/trace_bench.rb
+++ b/benchmarks/fasta/ruby/trace_bench.rb
@@ -97,7 +97,6 @@ def make_random_fasta(table, n)
     EOF
 end
 
-# work around ruby scoping using lambda
 def run_iter(n)
     $last = INITIAL_STATE
     puts "def run_iter(n)"

--- a/warmup.krun
+++ b/warmup.krun
@@ -132,9 +132,6 @@ SKIP=[
     # XXX: Really slow
     "richards:HHVM:default-php",
 
-    # XXX: This crashes, after about 250 iterations.
-    "spectralnorm:JRubyTruffle:default-ruby",
-
     # XXX: This benchmark is slow *and* crashes
     "fasta:JRubyTruffle:default-ruby",
 


### PR DESCRIPTION
This re-enables a benchmark (spectralnorm:JRubyTruffle) which no longer crashes, and also performs OK now (about a second per in-process iteration).

There were two other previously misbehaving benchmarks I investigated too:
- fasta:JRubyTruffle no longer crashes but has a checksum error only under Jrubytruffle. Reported to Chris. Details: https://gist.github.com/vext01/4f5547c6199b2542ba8f5fd9e7b6abf0
- richards:HHVM is still amazingly slow. About 35 seconds per in-process iteration. We could enable this and add 8 days to the experiment. What do you think?

Also tidied up some bogus and somewhat redundant comments.
