### PR TITLE
Trailing comma.

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -82,7 +82,7 @@ VMS = {
 
 if not sys.platform.startswith("openbsd"):
     JVMCI_JAVA_HOME = find_internal_jvmci_java_home('work/jvmci/')
-    JVMCI_JAVA_BIN = find_internal_jvmci_java_bin('work/jvmci/'),
+    JVMCI_JAVA_BIN = find_internal_jvmci_java_bin('work/jvmci/')
 
     # The following VMs do not run on OpenBSD.
     VMS.update({


### PR DESCRIPTION
Causes the value to be a tuple, upsetting krun.
