### PR TITLE
Fix startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 CC=${PWD}/work/gcc-inst/bin/zgcc
 
-all: build-vms build-benchmarks build-krun
+all: build-vms build-benchmarks build-krun build-startup
 	@echo ""
 	@echo "============================================================"
 	@echo "Now run 'make bench-no-reboots' or 'make bench-with-reboots'"

--- a/startup.krun
+++ b/startup.krun
@@ -1,8 +1,5 @@
-import os
-from krun.vm_defs import (PythonVMDef, LuaVMDef, JavaVMDef, GraalVMDef,
-    PHPVMDef, JRubyTruffleVMDef, V8VMDef, NativeCodeVMDef,
-    find_internal_jvmci_java_bin, GenericScriptingVMDef)
-from krun import EntryPoint
+execfile("warmup.krun", globals()) # import the warmup definitions completely
+
 
 # this file is a minimally hacky way to do startup measurements with all the
 # krun goodies, but without changing krun.
@@ -12,8 +9,7 @@ from krun import EntryPoint
 #
 # before the invocation of the VM, another executable is inserted:
 #
-# sudo -u krun nice -20 taskset 0x2 env <some variables> \
-# outer_startup_runner_c jruby startup_runner.rb
+# env <some variables> outer_startup_runner_c jruby startup_runner.rb
 #
 # outer_startup_runner_c is a small C program that prints the current time,
 # then execs its arguments. startup_runner.rb will then also print the current
@@ -30,29 +26,7 @@ from krun import EntryPoint
 #   outer_startup_runner_c
 #
 
-# Who to mail
-MAIL_TO = []
-
-# Maximum number of error emails to send per-run
-#MAX_MAILS = 2
-
-DIR = os.getcwd()
-JKRUNTIME_DIR = os.path.join(DIR, "krun", "libkruntime", "")
-JDK8_HOME = os.path.join(DIR, "work/openjdk/build/linux-x86_64-normal-server-release/images/j2sdk-image/")
 STARTUP_RUNNER_DIR = os.path.join(DIR, "startup_runners")
-
-HEAP_LIMIT = 2097152  # K == 2Gb
-
-# Variant name -> EntryPoint
-VARIANTS = {
-    "default-c": EntryPoint("bench.so", subdir="c"),
-    "default-java": EntryPoint("KrunEntry", subdir="java"),
-    "default-lua": EntryPoint("bench.lua", subdir="lua"),
-    "default-python": EntryPoint("bench.py", subdir="python"),
-    "default-php": EntryPoint("bench.php", subdir="php"),
-    "default-ruby": EntryPoint("bench.rb", subdir="ruby"),
-    "default-javascript": EntryPoint("bench.js", subdir="javascript"),
-}
 
 ITERATIONS_ALL_VMS = 1
 
@@ -81,93 +55,23 @@ def patch_platform(platform):
         # this function inserts the outer runner into the arguments
         prepend_args = BasePlatform.bench_cmdline_adjust(self, [], env_dct)
         # all platform checks are also run with the same mechanism, meaning their
-        # output needs to be valid JSON. When running check_user_change, this is
-        # not the case when using the outer startup runner. Therefore, we don't.
-        if "check_user_change" in args[-3]:
+	# output needs to be valid JSON. When running them, this is not the
+	# case when using the outer startup runner. Therefore, we don't.
+        if "platform_sanity_check" in args[-3]:
             return prepend_args + args
-        return prepend_args + ["startup_runners/outer_startup_runner_c"] + args
+	return prepend_args + ["startup_runners/outer_startup_runner_c"] + args
     assert Cls.__dict__.get('bench_cmdline_adjust') is None
     Cls.bench_cmdline_adjust = bench_cmdline_adjust
 
-patch_platform(detect_platform(None))
+patch_platform(detect_platform(None, None))
 
-VMS = {
-        'C': {
-                'vm_def': patch_runner(NativeCodeVMDef()),
-                'variants': ['default-c'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-
-        },
-        'PyPy': {
-                'vm_def': patch_runner(PythonVMDef('work/pypy/pypy/goal/pypy-c')),
-                'variants': ['default-python'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-        },
-        'Hotspot': {
-                'vm_def': patch_runner(JavaVMDef('work/openjdk/build/linux-x86_64-normal-server-release/images/j2sdk-image/bin/java')),
-                'variants': ['default-java'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-        },
-        'Graal': {
-                'vm_def': patch_runner(GraalVMDef(find_internal_jvmci_java_bin('work/jvmci/'), JDK8_HOME)),
-                'variants': ['default-java'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-        },
-        'LuaJIT': {
-                'vm_def': patch_runner(LuaVMDef('work/luajit/src/luajit')),
-                'variants': ['default-lua'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-        },
-        'HHVM': {
-                'vm_def': patch_runner(PHPVMDef('work/hhvm/hphp/hhvm/php')),
-                'variants': ['default-php'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-        },
-        'JRubyTruffle' : {
-                'vm_def': patch_runner(JRubyTruffleVMDef('work/jruby/bin/jruby',
-                                            java_path=find_internal_jvmci_java_bin('work/jvmci/'))),
-                'variants': ['default-ruby'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-        },
-        'V8': {
-                'vm_def': patch_runner(V8VMDef('work/v8/out/native/d8')),
-                'variants': ['default-javascript'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-        },
-        'CPython': {
-                'vm_def': patch_runner(PythonVMDef('work/cpython-inst/bin/python')),
-                'variants': ['default-python'],
-                'n_iterations': ITERATIONS_ALL_VMS,
-                'warm_upon_iter': 0,
-        }
-}
-
+for name, dct in VMS.items():
+    dct['vm_def'] = patch_runner(dct['vm_def'])
 
 BENCHMARKS = {
-    # this is ignored by the startup runner, but we use an existing one as a
+    # this is ignored by the startup runner, but we use one existing one as a
     # dummy
     'binarytrees': 18,
 }
 
-# list of "bench:vm:variant"
-SKIP=[
-    #"*:PyPy:*",
-    #"*:CPython:*",
-    #"*:Hotspot:*",
-    #"*:Graal:*",
-    #"*:LuaJIT:*",
-    #"*:HHVM:*",
-    #"*:JRubyTruffle:*",
-    #"*:V8:*",
-]
-
 N_EXECUTIONS = 200  # Number of fresh processes.
-N_GRAPHS_PER_BENCH = 2

--- a/startup_runners/Makefile
+++ b/startup_runners/Makefile
@@ -19,13 +19,13 @@ startup_runner.class: startup_runner.java
 
 
 outer_startup_runner_c: outer_startup_runner.c
-	${CC} ${C_ITER_RUNNER_CFLAGS} ${CFLAGS} -L${PWD}/../krun/libkruntime \
+	${CC} ${C_ITER_RUNNER_CFLAGS} ${CFLAGS} -L${PWD}/../krun/libkrun \
 		${CPPFLAGS} outer_startup_runner.c \
 		-o outer_startup_runner_c -lkruntime ${C_ITER_RUNNER_LDFLAGS} \
 		${LDFLAGS}
 
 startup_runner_c: startup_runner.c
-	${CC} ${C_ITER_RUNNER_CFLAGS} ${CFLAGS} -L${PWD}/../krun/libkruntime \
+	${CC} ${C_ITER_RUNNER_CFLAGS} ${CFLAGS} -L${PWD}/../krun/libkrun \
 		${CPPFLAGS} startup_runner.c \
 		-o startup_runner_c -lkruntime ${C_ITER_RUNNER_LDFLAGS} \
 		${LDFLAGS}

--- a/startup_runners/startup_runner.rb
+++ b/startup_runners/startup_runner.rb
@@ -1,13 +1,5 @@
-if RUBY_PLATFORM == "java" then
-    # "java" means JRuby.
-    def clock_gettime_monotonic()
-        # JRuby does not (yet) provide access to the (raw) monotonic clock, and
-        # adding support is non-trivial (not as simple as adding the C
-        # constant).  For now we patch JRuby/Truffle to expose our libkruntime
-        # function.
-        Truffle::Primitive.clock_gettime_monotonic()
-    end
-elsif /linux/ =~ RUBY_PLATFORM then
+# defined this way so we don't measure the conditional platform check.
+if /linux/ =~ RUBY_PLATFORM then
     def clock_gettime_monotonic()
         Process.clock_gettime(Process::CLOCK_MONOTONIC_RAW)
     end


### PR DESCRIPTION
This pull request syncs `startup.krun` to the changes that were done in krun. The core approach of how startup is measured stays the same. The pull request also makes `startup.krun` contain considerably less copy-pasted code, which means it should be more robust to future changes.
