### PR TITLE
Make outliers more visible.

### DIFF
--- a/plot_krun_results.py
+++ b/plot_krun_results.py
@@ -70,13 +70,13 @@ FILL_ALPHA = 0.2
 
 OUTLIER_MARKER = 'o'
 OUTLIER_COLOR = 'r'
-OUTLIER_SIZE = 20
+OUTLIER_SIZE = 80
 UNIQUE_COLOR = 'g'
 UNIQUE_MARKER = 'o'
-UNIQUE_SIZE = 20
+UNIQUE_SIZE = 80
 COMMON_COLOR = 'r'
 COMMON_MARKER = '*'
-COMMON_SIZE = 40
+COMMON_SIZE = 80
 
 # Inset placement (left, bottom, width, height) relative to subplot axis.
 INSET_RECT = (0.675, 0.82, 0.3, 0.15)


### PR DESCRIPTION
This PR embiggens all the blobs that mark outliers, as in the attached example.

![embiggen_the_blobs](https://cloud.githubusercontent.com/assets/97674/17442306/1106cf94-5b2d-11e6-9fb3-1e7ec9dca758.png)
