### PR TITLE
New TSR interfaces for VMs.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -479,7 +479,11 @@ build_hhvm() {
     ln -sf ${OUR_CXX} `dirname ${OUR_CXX}`/g++ || exit $?
     HHVM_PATH=`dirname ${OUR_CC}`:${PATH}
 
-    env PATH=${HHVM_PATH} CC=${OUR_CC} CXX=${OUR_CXX} sh -c "cmake -DMYSQL_UNIX_SOCK_ADDR=/dev/null -DBOOST_LIBRARYDIR=/usr/lib/x86_64-linux-gnu/ . && ${GMAKE}" || exit $?
+    env LIBKRUN_DIR=${HERE}/krun/libkrun PATH=${HHVM_PATH} CC=${OUR_CC} \
+        CXX=${OUR_CXX} sh -c \
+        "cmake -DMYSQL_UNIX_SOCK_ADDR=/dev/null -DBOOST_LIBRARYDIR=/usr/lib/x86_64-linux-gnu/ -DCMAKE_CXX_FLAGS=-I${HERE}/krun/libkrun . " \
+        || exit $?
+    ${GMAKE} VERBOSE=1 || exit $?
 
     # remove the symlinks
     rm `dirname ${OUR_CC}`/gcc `dirname ${OUR_CC}`/g++ || exit $?

--- a/patches/hhvm_exts.diff
+++ b/patches/hhvm_exts.diff
@@ -1,8 +1,22 @@
+diff --git a/hphp/hhvm/CMakeLists.txt b/hphp/hhvm/CMakeLists.txt
+index 1d0822d..ad3e69b 100644
+--- a/hphp/hhvm/CMakeLists.txt
++++ b/hphp/hhvm/CMakeLists.txt
+@@ -37,6 +37,9 @@ if(CYGWIN)
+   target_link_libraries(hhvm dbghelp)
+ endif()
+ 
++# softdev
++target_link_libraries(hhvm "$ENV{LIBKRUN_DIR}/libkruntime.so")
++
+ # Check whether atomic operations require -latomic or not
+ # See https://github.com/facebook/hhvm/issues/5217
+ INCLUDE(CheckCXXSourceCompiles)
 diff --git a/hphp/runtime/ext/std/ext_std_misc.cpp b/hphp/runtime/ext/std/ext_std_misc.cpp
-index 8b08cec..2c82348 100644
+index 8b08cec..f098a32 100644
 --- a/hphp/runtime/ext/std/ext_std_misc.cpp
 +++ b/hphp/runtime/ext/std/ext_std_misc.cpp
-@@ -44,10 +44,14 @@
+@@ -44,10 +44,15 @@
  #include "hphp/util/current-executable.h"
  #include "hphp/util/logger.h"
  
@@ -13,20 +27,22 @@ index 8b08cec..2c82348 100644
  #endif
  
 +#include <time.h>
++#include <libkruntime.h>
 +
  namespace HPHP {
  
  IMPLEMENT_THREAD_LOCAL(std::string, s_misc_highlight_default_string);
-@@ -192,6 +196,8 @@ void StandardExtension::initMisc() {
+@@ -192,6 +197,9 @@ void StandardExtension::initMisc() {
      HHVM_FE(sys_getloadavg);
      HHVM_FE(token_get_all);
      HHVM_FE(token_name);
 +    HHVM_FE(clock_gettime_monotonic);
-+    HHVM_FE(read_ts_reg);
++    HHVM_FE(read_ts_reg_start_double);
++    HHVM_FE(read_ts_reg_stop_double);
      HHVM_FE(hphp_to_string);
      HHVM_FALIAS(__SystemLib\\max2, SystemLib_max2);
      HHVM_FALIAS(__SystemLib\\min2, SystemLib_min2);
-@@ -966,5 +972,46 @@ Variant HHVM_FUNCTION(SystemLib_min2, const Variant& value1,
+@@ -966,5 +974,36 @@ Variant HHVM_FUNCTION(SystemLib_min2, const Variant& value1,
  #undef YYTOKEN_MAP
  #undef YYTOKEN
  
@@ -53,44 +69,35 @@ index 8b08cec..2c82348 100644
 +	return (result);
 +}
 +
-+/*
-+ * Derived from:
-+ * $OpenBSD: pctr.h,v 1.5 2014/03/29 18:09:28 guenther Exp$
-+ *
-+ * PHP has no way to represent a unsigned 64-bit integer. We return a signed
-+ * 64. Any app-level code using this must know that this is really a unsigned
-+ * value.
-+ */
-+double HHVM_FUNCTION(read_ts_reg) {
-+    u_int32_t hi, lo;
-+    u_int64_t val;
++double HHVM_FUNCTION(read_ts_reg_start_double) {
++    return read_ts_reg_start_double();
++}
 +
-+    __asm volatile("rdtsc" : "=d" (hi), "=a" (lo));
-+    val = ((u_int64_t) hi << 32) | (u_int64_t) lo;
-+
-+    return (double) val;
++double HHVM_FUNCTION(read_ts_reg_stop_double) {
++    return read_ts_reg_stop_double();
 +}
 +
  ///////////////////////////////////////////////////////////////////////////////
  }
 diff --git a/hphp/runtime/ext/std/ext_std_misc.h b/hphp/runtime/ext/std/ext_std_misc.h
-index 49db8a5..a6d693a 100644
+index 49db8a5..172a192 100644
 --- a/hphp/runtime/ext/std/ext_std_misc.h
 +++ b/hphp/runtime/ext/std/ext_std_misc.h
-@@ -48,6 +48,8 @@ Variant HHVM_FUNCTION(unpack, const String& format, const String& data);
+@@ -48,6 +48,9 @@ Variant HHVM_FUNCTION(unpack, const String& format, const String& data);
  Array HHVM_FUNCTION(sys_getloadavg);
  Array HHVM_FUNCTION(token_get_all, const String& source);
  String HHVM_FUNCTION(token_name, int64_t token);
 +double HHVM_FUNCTION(clock_gettime_monotonic);
-+double HHVM_FUNCTION(read_ts_reg);
++double HHVM_FUNCTION(read_ts_reg_start_double);
++double HHVM_FUNCTION(read_ts_reg_stop_double);
  String HHVM_FUNCTION(hphp_to_string, const Variant& v);
  Variant HHVM_FUNCTION(SystemLib_max2, const Variant& arg1, const Variant& arg2);
  Variant HHVM_FUNCTION(SystemLib_min2, const Variant& arg1, const Variant& arg2);
 diff --git a/hphp/runtime/ext/std/ext_std_misc.php b/hphp/runtime/ext/std/ext_std_misc.php
-index da36140..40a36a1 100644
+index da36140..8f7ed9a 100644
 --- a/hphp/runtime/ext/std/ext_std_misc.php
 +++ b/hphp/runtime/ext/std/ext_std_misc.php
-@@ -214,6 +214,14 @@ function token_get_all(string $source): array;
+@@ -214,6 +214,16 @@ function token_get_all(string $source): array;
  <<__ParamCoerceModeFalse, __Native>>
  function token_name(int $token): string;
  
@@ -98,9 +105,11 @@ index da36140..40a36a1 100644
 +<<__Native>>
 +function clock_gettime_monotonic(): double;
 +
-+/* Returns the value of the timestamp register */
++/* Timestamp register */
 +<<__Native>>
-+function read_ts_reg(): double;
++function read_ts_reg_start_double(): double;
++<<__Native>>
++function read_ts_reg_stop_double(): double;
 +
  /* Casts a given value to a string.
   * @param mixed $v - The value being casted to a string.

--- a/patches/jruby_tsr.diff
+++ b/patches/jruby_tsr.diff
@@ -1,5 +1,5 @@
 diff --git a/truffle/src/main/java/org/jruby/truffle/RubyContext.java b/truffle/src/main/java/org/jruby/truffle/RubyContext.java
-index b0cbb23..481778f 100644
+index b0cbb23..d0691aa 100644
 --- a/truffle/src/main/java/org/jruby/truffle/RubyContext.java
 +++ b/truffle/src/main/java/org/jruby/truffle/RubyContext.java
 @@ -56,6 +56,8 @@ import java.io.PrintStream;
@@ -15,7 +15,7 @@ index b0cbb23..481778f 100644
      private final PrintStream debugStandardOut;
      private final CoverageManager coverageManager;
  
-+    private final ReadTSReg readTSReg;
++    private final LibKrunTime libKrunTime;
 +
      private final Object classVariableDefinitionLock = new Object();
  
@@ -24,9 +24,9 @@ index b0cbb23..481778f 100644
          final PrintStream configStandardOut = jrubyRuntime.getInstanceConfig().getOutput();
          debugStandardOut = (configStandardOut == System.out) ? null : configStandardOut;
  
-+        final LibraryLoader<ReadTSReg> readTSRegLoader = LibraryLoader.create(ReadTSReg.class);
-+        readTSRegLoader.library("kruntime");
-+        readTSReg = readTSRegLoader.load();
++        final LibraryLoader<LibKrunTime> libKrunTimeLoader = LibraryLoader.create(LibKrunTime.class);
++        libKrunTimeLoader.library("kruntime");
++        libKrunTime = libKrunTimeLoader.load();
 +
          if (options.INSTRUMENTATION_SERVER_PORT != 0) {
              instrumentationServerManager = new InstrumentationServerManager(this, options.INSTRUMENTATION_SERVER_PORT);
@@ -35,41 +35,82 @@ index b0cbb23..481778f 100644
          return coreExceptions;
      }
  
-+    public ReadTSReg readTSReg() {
-+        return readTSReg;
++    public LibKrunTime getLibKrunTime() {
++        return libKrunTime;
 +    }
  }
 diff --git a/truffle/src/main/java/org/jruby/truffle/core/kernel/KernelNodes.java b/truffle/src/main/java/org/jruby/truffle/core/kernel/KernelNodes.java
-index 50a155d..f183bdc 100644
+index 50a155d..0234ef7 100644
 --- a/truffle/src/main/java/org/jruby/truffle/core/kernel/KernelNodes.java
 +++ b/truffle/src/main/java/org/jruby/truffle/core/kernel/KernelNodes.java
-@@ -1985,4 +1985,18 @@ public abstract class KernelNodes {
+@@ -141,6 +141,7 @@ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.List;
+ import java.util.Map;
++import java.math.BigInteger;
+ 
+ @CoreClass("Kernel")
+ public abstract class KernelNodes {
+@@ -1985,4 +1986,49 @@ public abstract class KernelNodes {
  
      }
  
-+    @CoreMethod(names = "read_ts_reg", needsSelf=false)
-+    public abstract static class ReadTSRegNode extends CoreMethodArrayArgumentsNode {
++    @CoreMethod(names = "read_ts_reg_start", needsSelf=false)
++    public abstract static class ReadTSRegStartNode extends CoreMethodArrayArgumentsNode {
 +
-+        public ReadTSRegNode(RubyContext context, SourceSection sourceSection) {
++        private static final BigInteger negAdjust = BigInteger.ONE.shiftLeft(64); // 2^64
++
++        public ReadTSRegStartNode(RubyContext context, SourceSection sourceSection) {
 +            super(context, sourceSection);
 +        }
 +
 +        @TruffleBoundary
 +        @Specialization
-+        public long ReadTSReg() {
-+            return getContext().readTSReg().read_ts_reg();
++        public DynamicObject readTSRegStart() {
++            final long u64_in_s64 = getContext().getLibKrunTime().read_ts_reg_start();
++
++            BigInteger bi = BigInteger.valueOf(u64_in_s64);
++            if (u64_in_s64 < 0) {
++                bi = bi.add(ReadTSRegStartNode.negAdjust);
++            }
++
++            return createBignum(bi);
++        }
++    }
++
++    @CoreMethod(names = "read_ts_reg_stop", needsSelf=false)
++    public abstract static class ReadTSRegStopNode extends CoreMethodArrayArgumentsNode {
++
++        private static final BigInteger negAdjust = BigInteger.ONE.shiftLeft(64); // 2^64
++
++        public ReadTSRegStopNode(RubyContext context, SourceSection sourceSection) {
++            super(context, sourceSection);
 +        }
 +
++        @TruffleBoundary
++        @Specialization
++        public DynamicObject readTSRegStop() {
++            final long u64_in_s64 = getContext().getLibKrunTime().read_ts_reg_stop();
++
++            BigInteger bi = BigInteger.valueOf(u64_in_s64);
++            if (u64_in_s64 < 0) {
++                bi = bi.add(ReadTSRegStopNode.negAdjust);
++            }
++
++            return createBignum(bi);
++        }
 +    }
  }
-diff --git a/truffle/src/main/java/org/jruby/truffle/core/kernel/ReadTSReg.java b/truffle/src/main/java/org/jruby/truffle/core/kernel/ReadTSReg.java
+diff --git a/truffle/src/main/java/org/jruby/truffle/core/kernel/LibKrunTime.java b/truffle/src/main/java/org/jruby/truffle/core/kernel/LibKrunTime.java
 new file mode 100644
-index 0000000..b94a4c8
+index 0000000..3aa02af
 --- /dev/null
-+++ b/truffle/src/main/java/org/jruby/truffle/core/kernel/ReadTSReg.java
-@@ -0,0 +1,5 @@
++++ b/truffle/src/main/java/org/jruby/truffle/core/kernel/LibKrunTime.java
+@@ -0,0 +1,7 @@
 +package org.jruby.truffle;
 +
-+public interface ReadTSReg {
-+    long read_ts_reg();
++public interface LibKrunTime {
++    // these actually return u_int64_t
++    long read_ts_reg_start();
++    long read_ts_reg_stop();
 +}

--- a/patches/v8_various.diff
+++ b/patches/v8_various.diff
@@ -1,8 +1,8 @@
 diff --git a/src/d8.cc b/src/d8.cc
-index 0688380..9c26907 100644
+index 0688380..edd637d 100644
 --- a/src/d8.cc
 +++ b/src/d8.cc
-@@ -2,6 +2,20 @@
+@@ -2,6 +2,21 @@
  // Use of this source code is governed by a BSD-style license that can be
  // found in the LICENSE file.
  
@@ -14,6 +14,7 @@ index 0688380..9c26907 100644
 +#include <math.h>
 +#include <errno.h>
 +#include <stdio.h>
++#include <libkruntime.h>
 +
 +#if defined(__linux__)
 +#define ACTUAL_CLOCK_MONOTONIC    CLOCK_MONOTONIC_RAW
@@ -23,7 +24,7 @@ index 0688380..9c26907 100644
  
  // Defined when linking against shared lib on Windows.
  #if defined(USING_V8_SHARED) && !defined(V8_SHARED)
-@@ -627,6 +641,39 @@ void Shell::Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
+@@ -627,6 +642,32 @@ void Shell::Print(const v8::FunctionCallbackInfo<v8::Value>& args) {
    fflush(stdout);
  }
  
@@ -46,24 +47,17 @@ index 0688380..9c26907 100644
 +  args.GetReturnValue().Set(result);
 +}
 +
-+/*
-+ * Derived from:
-+ * $OpenBSD: pctr.h,v 1.5 2014/03/29 18:09:28 guenther Exp$
-+ */
-+void Shell::ReadTSReg(const v8::FunctionCallbackInfo<v8::Value>& args) {
-+    u_int32_t hi, lo;
-+    u_int64_t result;
++void Shell::ReadTSRegStartDouble(const v8::FunctionCallbackInfo<v8::Value>& args) {
++    args.GetReturnValue().Set(read_ts_reg_start_double());
++}
 +
-+    __asm volatile("rdtsc" : "=d" (hi), "=a" (lo));
-+    result = ((u_int64_t) hi << 32) | (u_int64_t) lo;
-+
-+    // the cast is not ideal
-+    args.GetReturnValue().Set((double) result);
++void Shell::ReadTSRegStopDouble(const v8::FunctionCallbackInfo<v8::Value>& args) {
++    args.GetReturnValue().Set(read_ts_reg_stop_double());
 +}
  
  void Shell::Write(const v8::FunctionCallbackInfo<v8::Value>& args) {
    for (int i = 0; i < args.Length(); i++) {
-@@ -658,6 +705,33 @@ void Shell::Write(const v8::FunctionCallbackInfo<v8::Value>& args) {
+@@ -658,6 +699,33 @@ void Shell::Write(const v8::FunctionCallbackInfo<v8::Value>& args) {
    }
  }
  
@@ -97,7 +91,7 @@ index 0688380..9c26907 100644
  
  void Shell::Read(const v8::FunctionCallbackInfo<v8::Value>& args) {
    String::Utf8Value file(args[0]);
-@@ -1082,10 +1156,26 @@ Local<ObjectTemplate> Shell::CreateGlobalTemplate(Isolate* isolate) {
+@@ -1082,10 +1150,30 @@ Local<ObjectTemplate> Shell::CreateGlobalTemplate(Isolate* isolate) {
            .ToLocalChecked(),
        FunctionTemplate::New(isolate, Print));
    global_template->Set(
@@ -109,9 +103,13 @@ index 0688380..9c26907 100644
 +          .ToLocalChecked(),
 +      FunctionTemplate::New(isolate, ClockGettimeMonotonic));
 +  global_template->Set(
-+      String::NewFromUtf8(isolate, "read_ts_reg", NewStringType::kNormal)
++      String::NewFromUtf8(isolate, "read_ts_reg_start_double", NewStringType::kNormal)
 +          .ToLocalChecked(),
-+      FunctionTemplate::New(isolate, ReadTSReg));
++      FunctionTemplate::New(isolate, ReadTSRegStartDouble));
++  global_template->Set(
++      String::NewFromUtf8(isolate, "read_ts_reg_stop_double", NewStringType::kNormal)
++          .ToLocalChecked(),
++      FunctionTemplate::New(isolate, ReadTSRegStopDouble));
 +  global_template->Set(
        String::NewFromUtf8(isolate, "write", NewStringType::kNormal)
            .ToLocalChecked(),
@@ -124,17 +122,40 @@ index 0688380..9c26907 100644
        String::NewFromUtf8(isolate, "read", NewStringType::kNormal)
            .ToLocalChecked(),
        FunctionTemplate::New(isolate, Read));
+diff --git a/src/d8.gyp b/src/d8.gyp
+index f249a78..38a5003 100644
+--- a/src/d8.gyp
++++ b/src/d8.gyp
+@@ -46,6 +46,17 @@
+       'include_dirs+': [
+         '..',
+       ],
++      'link_settings': {
++        'libraries+': [
++          '-lkruntime',
++	],
++        'ldflags+': [
++          '-L<!(echo $LIBKRUN_DIR)',
++        ],
++      },
++      'cflags_cc+': [
++	'-I<!(echo $LIBKRUN_DIR)',
++      ],
+       'sources': [
+         'd8.h',
+         'd8.cc',
 diff --git a/src/d8.h b/src/d8.h
-index 321d9c1..64e1c94 100644
+index 321d9c1..62cea9b 100644
 --- a/src/d8.h
 +++ b/src/d8.h
-@@ -385,7 +385,11 @@ class Shell : public i::AllStatic {
+@@ -385,7 +385,12 @@ class Shell : public i::AllStatic {
                               const  PropertyCallbackInfo<void>& info);
  
    static void Print(const v8::FunctionCallbackInfo<v8::Value>& args);
 +  static void PrintErr(const v8::FunctionCallbackInfo<v8::Value>& args);
 +  static void ClockGettimeMonotonic(const v8::FunctionCallbackInfo<v8::Value>& args);
-+  static void ReadTSReg(const v8::FunctionCallbackInfo<v8::Value>& args);
++  static void ReadTSRegStartDouble(const v8::FunctionCallbackInfo<v8::Value>& args);
++  static void ReadTSRegStopDouble(const v8::FunctionCallbackInfo<v8::Value>& args);
    static void Write(const v8::FunctionCallbackInfo<v8::Value>& args);
 +  static void WriteErr(const v8::FunctionCallbackInfo<v8::Value>& args);
    static void QuitOnce(v8::FunctionCallbackInfo<v8::Value>* args);


### PR DESCRIPTION
In response to: https://github.com/softdevteam/krun/pull/238

Note that the new TSR functions now all use libkruntime instead of duplicating code in the VM itself. The support code was getting large and I was worried that we might end up in a situation where the code falls out of sync between VMs and libkruntime.

There is still duplication WRT `clock_gettime_monotonic`, but I will raise a separate PR to fix that next (make them use libkrun too).

Note the ruby support is special. It now always returns a Ruby `Bignum`.

OK?
