### PR TITLE
New outlier calculations

### DIFF
--- a/mark_outliers_in_json.py
+++ b/mark_outliers_in_json.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.7
 """
 Determine which iterations in Krun data are outliers, where an outlier is
-greater than 5 sigma above from a rolling mean.
+greater than 6 sigmas above / below a rolling mean.
 
 usage: Write lists of outliers into Krun results file(s).
 Example usage:
@@ -76,16 +76,24 @@ def get_outliers(all_outliers, window_size, threshold=1):
     return common, unique
 
 
-def get_all_outliers(data, window_size):
+def _tuckey_all_outliers(data, window_size):
+    # Ignore windows that do not have a full set of data.
     all_outliers = list()
     for index, datum in enumerate(data):
         l_slice, r_slice = _clamp_window_size(index, len(data), window_size)
+        if l_slice == 0 and r_slice < window_size:
+            continue
         window = data[l_slice:r_slice]
-        mean = numpy.mean(window)
-        five_sigma = 5 * numpy.std(window)
-        if datum > (mean + five_sigma) or datum < (mean - five_sigma):
+        median = numpy.median(window)
+        pc_band = (3 * (numpy.percentile(window, 90.0, interpolation='nearest')
+                        - numpy.percentile(window, 10.0, interpolation='nearest')))
+        if datum > (median + pc_band) or datum < (median - pc_band):
             all_outliers.append(index)
     return all_outliers
+
+
+def get_all_outliers(data, window_size):
+    return _tuckey_all_outliers(data, window_size)
 
 
 def _clamp_window_size(index, data_size, window_size=200):

--- a/plot_outliers_by_threshold.py
+++ b/plot_outliers_by_threshold.py
@@ -8,6 +8,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import FormatStrFormatter, FuncFormatter, MaxNLocator
 import numpy
 import os
 import os.path
@@ -38,7 +39,6 @@ GRID_MAJOR_X_DIVS = 10
 GRID_MINOR_Y_DIVS = 12
 GRID_MAJOR_Y_DIVS = 6
 
-XTICK_FORMAT = '%d'
 YTICK_FORMAT = '%d'
 YLIM_ADJUST = 250
 
@@ -92,7 +92,7 @@ def plot_results(outliers_per_thresh, filename):
         window = WINDOWS[index]
         axis = axes[row, col]
         axis.ticklabel_format(useOffset=False)
-        x_bounds = (1, len(outliers_per_thresh[window].keys()))
+        x_bounds = (0, len(outliers_per_thresh[window].keys()))
         axis.set_xlim(x_bounds)
         axis.set_ylim(y_bounds)
         # Keep hold of handles / labels for legend.
@@ -106,25 +106,26 @@ def plot_results(outliers_per_thresh, filename):
     fig.subplots_adjust(**SUBPLOT_PARAMS)
     # Add margin to x-axis. Must be done *after* setting xlim and ylim
     # and calling subplots_adjust().
+    index, row, col = 0, 0, 0
     while index < num_windows:
         window = WINDOWS[index]
         axis = axes[row, col]
-        add_margin_to_axes(axis, x=0.02, y=0.02)
+        add_margin_to_axes(axis, x=0.02, y=0.00)
         col += 1
         if col == MAX_SUBPLOTS_PER_ROW:
             col = 0
             row += 1
         index = row * MAX_SUBPLOTS_PER_ROW + col
     fig.legend(handles, labels, loc='upper center', fontsize=LEGEND_FONTSIZE, ncol=10,)
-    pdf.savefig(fig, dpi=fig.dpi, orientation='portait', bbox_inches='tight')
+    pdf.savefig(fig, dpi=fig.dpi, orientation='portrait', bbox_inches='tight')
     pdf.close()
     print('Saved: %s' % filename)
 
 
 def draw_subplot(axis, data, x_range, y_range, window_size):
-    all_ = [0]
-    common = [0]
-    unique = [0]
+    all_ = []
+    common = []
+    unique = []
     for threshold in data:
         all_.append(data[threshold]['all_outliers'])
         common.append(data[threshold]['common_outliers'])
@@ -150,9 +151,9 @@ def draw_subplot(axis, data, x_range, y_range, window_size):
     axis.set_ylabel('Number of outliers', fontsize=AXIS_FONTSIZE)
     axis.set_ylim(y_range)
     # Format ticks.
-    axis.xaxis.set_major_locator(matplotlib.ticker.MaxNLocator(integer=True))
-    axis.xaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter(XTICK_FORMAT))
-    axis.yaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter(YTICK_FORMAT))
+    axis.xaxis.set_major_locator(MaxNLocator(integer=True, steps=xrange(11)))
+    axis.xaxis.set_major_formatter(FuncFormatter(lambda x, pos: str(int(x + 1))))
+    axis.yaxis.set_major_formatter(FormatStrFormatter(YTICK_FORMAT))
     # Return artists needed for legend.
     handles, labels = axis.get_legend_handles_labels()
     return handles, labels


### PR DESCRIPTION
**DO NOT MERGE**

This is ready for review, but cannot be merged because the code in `master` cannot read the 0.6 version of the data.

This PR replaces the old outlier calculations (mean and 5 sigma) with this formula from Tukey:

> +/- 3 (90^th percentile - 10^th percentile)

Command-line options for relevant scripts have been changed to match (e.g. we now pass `--median` rather than `--mean` to the plot_krun script).

Some visual improvements to the outliers-by-threshold chart are also included. Run sequences now look like this:

![current_per_threshold](https://cloud.githubusercontent.com/assets/97674/18264778/273b3eda-740a-11e6-949d-167a55772e25.png)

Needs squashing.

Fixes #149 
Fixes #139 
