### PR TITLE
add an "empty" benchmark

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -11,7 +11,8 @@ BENCHMARKS = 		binarytrees \
 			spectralnorm \
 			nbody \
 			fasta \
-			fannkuch_redux
+			fannkuch_redux \
+			empty
 
 # Extra linker flags for C benchmarks
 C_EXTRA_LDFLAGS_binarytrees = -lm

--- a/benchmarks/empty/c/bench.c
+++ b/benchmarks/empty/c/bench.c
@@ -1,0 +1,3 @@
+void run_iter(int n) {
+    return;
+}

--- a/benchmarks/empty/c/trace_bench.c
+++ b/benchmarks/empty/c/trace_bench.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void run_iter(int n) {
+    printf("void run_iter(int n) {\n");
+}

--- a/benchmarks/empty/java/KrunEntry.java
+++ b/benchmarks/empty/java/KrunEntry.java
@@ -1,0 +1,5 @@
+class KrunEntry implements BaseKrunEntry {
+
+  public void run_iter(int param) {
+  }
+}

--- a/benchmarks/empty/java/trace_KrunEntry.java
+++ b/benchmarks/empty/java/trace_KrunEntry.java
@@ -1,0 +1,4 @@
+class trace_KrunEntry implements BaseKrunEntry {
+  public void run_iter(int param) {
+  }
+}

--- a/benchmarks/empty/javascript/bench.js
+++ b/benchmarks/empty/javascript/bench.js
@@ -1,0 +1,2 @@
+function run_iter(n) {
+}

--- a/benchmarks/empty/javascript/trace_bench.js
+++ b/benchmarks/empty/javascript/trace_bench.js
@@ -1,0 +1,3 @@
+run_iter = function(n) {
+  print("run_iter = function(n) {");
+}

--- a/benchmarks/empty/lua/bench.lua
+++ b/benchmarks/empty/lua/bench.lua
@@ -1,0 +1,2 @@
+function run_iter(n)
+end

--- a/benchmarks/empty/lua/trace_bench.lua
+++ b/benchmarks/empty/lua/trace_bench.lua
@@ -1,0 +1,3 @@
+function run_iter(N)
+  print("function run_iter(N)")
+end

--- a/benchmarks/empty/php/bench.php
+++ b/benchmarks/empty/php/bench.php
@@ -1,0 +1,4 @@
+<?
+function run_iter($n) {
+}
+?>

--- a/benchmarks/empty/php/trace_bench.php
+++ b/benchmarks/empty/php/trace_bench.php
@@ -1,0 +1,6 @@
+<?
+function run_iter($n) {
+    echo 'function run_iter($n) {', "\n";
+}
+
+?>

--- a/benchmarks/empty/python/bench.py
+++ b/benchmarks/empty/python/bench.py
@@ -1,0 +1,2 @@
+def run_iter(n):
+    return

--- a/benchmarks/empty/python/trace_bench.py
+++ b/benchmarks/empty/python/trace_bench.py
@@ -1,0 +1,2 @@
+def run_iter(n, ref='sun'):
+    print "def run_iter(n, ref='sun'):"

--- a/benchmarks/empty/ruby/bench.rb
+++ b/benchmarks/empty/ruby/bench.rb
@@ -1,0 +1,2 @@
+def run_iter(n)
+end

--- a/benchmarks/empty/ruby/trace_bench.rb
+++ b/benchmarks/empty/ruby/trace_bench.rb
@@ -1,0 +1,3 @@
+def run_iter(n)
+    puts "def run_iter(n)"
+end

--- a/warmup.krun
+++ b/warmup.krun
@@ -113,6 +113,7 @@ BENCHMARKS = {
     'nbody': 15,
     'fasta': 100,
     'fannkuch_redux': 200,
+    'empty': 1,
 }
 
 # list of "bench:vm:variant"


### PR DESCRIPTION
It is used to get an estimate of the granularity and the overheads of the timers.

This was ready since a while, but I wanted to test it with the msr work. I just did, it simply works.
