### PR TITLE
Integrate Octane.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ benchmarks/binarytrees/c/bench.so
 benchmarks/fannkuch_redux/c/bench.so
 benchmarks/fasta/c/bench.so
 benchmarks/nbody/c/bench.so
-benchmarks/richards/c/bench.so                  
+benchmarks/richards/c/bench.so
 startup_runners/outer_startup_runner_c
 startup_runners/startup_runner_c
+*.results
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ bench-da-capo:
 	bin/csv_to_krun_json dacapo.csv
 
 bench-octane:
-	cd ${PWD}/extbench/octane && LD_LIBRARY_PATH=${PWD}/krun/libkrun ${PWD}/work/v8/out/native/d8 run.js
+	PYTHONPATH=krun/ ${PYTHON} extbench/runoctane.py
+	bin/csv_to_krun_json octane.v8.results
 
 # XXX target to format results.
 

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ bench-da-capo:
 	PYTHONPATH=krun/ JAVA_HOME=${JAVA_HOME} ${PYTHON} extbench/rundacapo.py | tee dacapo.csv
 	bin/csv_to_krun_json dacapo.csv
 
+bench-octane:
+	cd ${PWD}/extbench/octane && LD_LIBRARY_PATH=${PWD}/krun/libkrun ${PWD}/work/v8/out/native/d8 run.js
+
 # XXX target to format results.
 
 clean: clean-benchmarks clean-krun

--- a/build.sh
+++ b/build.sh
@@ -516,6 +516,21 @@ fetch_dacapo_jar() {
     wget "http://downloads.sourceforge.net/project/dacapobench/9.12-bach/dacapo-9.12-bach.jar?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fdacapobench%2Ffiles%2F&ts=1474888492&use_mirror=freefr" -O ${HERE}/extbench/dacapo-9.12-bach.jar  || exit $?
 }
 
+
+OCTANE_V=4852334f
+fetch_octane() {
+    echo "\n===> Download Octane\n"
+
+    if [ -d "${HERE}/extbench/octane" ]; then return; fi
+
+    cd ${HERE}/extbench
+    git clone https://github.com/chromium/octane || exit $?
+    cd octane
+    git checkout ${OCTANE_V} || exit $?
+    patch < ${PATCH_DIR}/octane.diff || exit $?
+}
+
+
 fetch_external_benchmarks() {
     echo "\n===> Download and build misc benchmarks\n"
 
@@ -566,6 +581,7 @@ case `uname` in
     build_initial_krun
     fetch_external_benchmarks
     fetch_dacapo_jar
+    fetch_octane
     build_gcc
     apply_gcc_lib_path
     fetch_libkalibera

--- a/extbench/runoctane.py
+++ b/extbench/runoctane.py
@@ -1,0 +1,61 @@
+#! /usr/bin/env python2.7
+
+import csv, os, sys, time
+from decimal import Decimal
+from krun.platform import detect_platform
+from krun.util import run_shell_cmd_bench
+
+WARMUP_DIR = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
+
+JAVASCRIPT_VMS = {
+    "v8": "sh -c 'cd %s/extbench/octane && LD_LIBRARY_PATH=%s/krun/libkrun %s/work/v8/out/native/d8 run.js'"
+          % (WARMUP_DIR, WARMUP_DIR, WARMUP_DIR)
+}
+
+ITERATIONS = 2000
+PROCESSES = 10
+
+def main():
+    platform = detect_platform(None, None)
+    for jsvm_name, jsvm_cmd in JAVASCRIPT_VMS.items():
+        with open("octane.%s.results" % jsvm_name, 'wb') as csvf:
+            sys.stdout.write("%s:" % jsvm_name)
+            writer = csv.writer(csvf)
+            writer.writerow(['processnum', 'benchmark'] + range(ITERATIONS))
+            for process in range(PROCESSES):
+                sys.stdout.write(" %s" % str(process))
+                sys.stdout.flush()
+                # Flush the CSV writing, and then give the OS some time
+                # to write stuff out to disk before running the next process
+                # execution.
+                csvf.flush()
+                os.fsync(csvf.fileno())
+                time.sleep(3)
+
+                stdout, stderr, rc = run_shell_cmd_bench(jsvm_cmd, platform)
+                if rc != 0:
+                    sys.stderr.write(stderr)
+                    sys.exit(rc)
+                times = None
+                for line in stdout.splitlines():
+                    assert len(line) > 0
+                    # Lines beginning with something other than a space are the
+                    # name of the next benchmark to run. Lines beginning with a
+                    # space are the timings of an iteration
+                    if line[0] == " ":
+                        # Times are in ms, so convert to seconds (without any
+                        # loss of precision).
+                        times.append(str(Decimal(line.strip()) / 1000))
+                    else:
+                        assert times is None or len(times) == ITERATIONS
+                        if times is not None:
+                            writer.writerow([process, bench_name] + times)
+                        bench_name = line.strip()
+                        times = []
+                assert len(times) == ITERATIONS
+                writer.writerow([process, bench_name] + times)
+            sys.stdout.write("\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/patches/octane.diff
+++ b/patches/octane.diff
@@ -45,7 +45,7 @@ index 9d6e3de..ce04d1b 100644
 -    this.NotifyStep(new BenchmarkResult(benchmark, usec, rms));
 -    return null;
 +    var end = new Date();
-+    print(end - start);
++    print("  " + (end - start));
    }
  }
  

--- a/patches/octane.diff
+++ b/patches/octane.diff
@@ -1,0 +1,112 @@
+diff --git a/base.js b/base.js
+index 9d6e3de..ce04d1b 100644
+--- a/base.js
++++ b/base.js
+@@ -296,39 +296,16 @@ BenchmarkSuite.prototype.RunSingleBenchmark = function(benchmark, data) {
+                         ? config.doDeterministic 
+                         : benchmark.doDeterministic;
+ 
+-  function Measure(data) {
+-    var elapsed = 0;
++  assert(doDeterministic);
++
++  print(benchmark.name);
++  for (var i = 0; i < 2000; i++) {
+     var start = new Date();
+-  
+-  // Run either for 1 second or for the number of iterations specified
+-  // by minIterations, depending on the config flag doDeterministic.
+-    for (var i = 0; (doDeterministic ? 
+-      i<benchmark.deterministicIterations : elapsed < 1000); i++) {
++    for (var j = 0; j < benchmark.deterministicIterations; j++) {
+       benchmark.run();
+-      elapsed = new Date() - start;
+-    }
+-    if (data != null) {
+-      data.runs += i;
+-      data.elapsed += elapsed;
+     }
+-  }
+-
+-  // Sets up data in order to skip or not the warmup phase.
+-  if (!doWarmup && data == null) {
+-    data = { runs: 0, elapsed: 0 };
+-  }
+-
+-  if (data == null) {
+-    Measure(null);
+-    return { runs: 0, elapsed: 0 };
+-  } else {
+-    Measure(data);
+-    // If we've run too few iterations, we continue for another second.
+-    if (data.runs < benchmark.minIterations) return data;
+-    var usec = (data.elapsed * 1000) / data.runs;
+-    var rms = (benchmark.rmsResult != null) ? benchmark.rmsResult() : 0;
+-    this.NotifyStep(new BenchmarkResult(benchmark, usec, rms));
+-    return null;
++    var end = new Date();
++    print(end - start);
+   }
+ }
+ 
+diff --git a/pdfjs.js b/pdfjs.js
+index 7953754..2d5584d 100644
+--- a/pdfjs.js
++++ b/pdfjs.js
+@@ -65,6 +65,7 @@ function runPdfJS() {
+ 
+   // Wait for everything to complete.
+   PdfJS_window.flushTimeouts();
++  canvas_logs.length = 0;
+ }
+ 
+ function tearDownPdfJS() {
+diff --git a/run.js b/run.js
+index d06a6be..395ad56 100644
+--- a/run.js
++++ b/run.js
+@@ -40,37 +40,33 @@ load(base_dir + 'pdfjs.js');
+ load(base_dir + 'mandreel.js');
+ load(base_dir + 'gbemu-part1.js');
+ load(base_dir + 'gbemu-part2.js');
+-load(base_dir + 'code-load.js');
++//load(base_dir + 'code-load.js');
+ load(base_dir + 'box2d.js');
+-load(base_dir + 'zlib.js');
+-load(base_dir + 'zlib-data.js');
++//load(base_dir + 'zlib.js');
++//load(base_dir + 'zlib-data.js');
+ load(base_dir + 'typescript.js');
+ load(base_dir + 'typescript-input.js');
+ load(base_dir + 'typescript-compiler.js');
+ 
++
+ var success = true;
+ 
+ function PrintResult(name, result) {
+-  print(name + ': ' + result);
+ }
+ 
+ 
+ function PrintError(name, error) {
+-  PrintResult(name, error);
+-  success = false;
++  print("Error: " + name + " " + error);
++  assert(false);
+ }
+ 
+ 
+ function PrintScore(score) {
+-  if (success) {
+-    print('----');
+-    print('Score (version ' + BenchmarkSuite.version + '): ' + score);
+-  }
+ }
+ 
+ 
+ BenchmarkSuite.config.doWarmup = undefined;
+-BenchmarkSuite.config.doDeterministic = undefined;
++BenchmarkSuite.config.doDeterministic = true;
+ 
+ BenchmarkSuite.RunSuites({ NotifyResult: PrintResult,
+                            NotifyError: PrintError,


### PR DESCRIPTION
_Not ready for merging yet_

Here's my first attempt at merging the Octane benchmark suite in. It's not Krun-ified (and we may never do so), and this PR will only tackle V8 (spidermonkey to come later, hopefully).

Octane benchmarks are, mostly, very quick to run so each benchmark says how many times it should be run to be "long enough". We then wrap that in a second loop of 2000 iterations. So the patch makes things look a bit like:

``` python
for i in range(2000):
  for j in range(benchmark.howmany):
    run_bench()
```

At the moment the output is of the form:

```
<bench>
<iter 1 in ms>
<iter 2 in ms>
...
```

e.g.:

```
richards
727
598
599
```

What's the right format to make it easy to graph the resulting data?
