### PR TITLE
Make the dacapo runner tee-less.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ bench-startup-no-reboots: build-startup build-benchmarks
 bench-startup-with-reboots: build-startup build-benchmarks
 	${PYTHON} krun/krun.py --reboot startup.krun
 
-bench-da-capo:
-	PYTHONPATH=krun/ JAVA_HOME=${JAVA_HOME} ${PYTHON} extbench/rundacapo.py | tee dacapo.csv
-	bin/csv_to_krun_json dacapo.csv
+bench-dacapo:
+	PYTHONPATH=krun/ JAVA_HOME=${JAVA_HOME} ${PYTHON} extbench/rundacapo.py
+	bin/csv_to_krun_json dacapo.hotspot.results
 
 export-graphs:
 	${PYTHON} export_all_graphs.py


### PR DESCRIPTION
Tee can do unpredictable things at unpredictable times, so we'd prefer it not to
be running at the same time as our benchmarks. Instead write the CSV to a file,
and flush and fsync at known safe points to lessen the chances of the OS doing
nasty things whilst we're benchmarking.

Whilst I'm here, make this look a bit more like the (upcoming) octane runner
which a) gives a minimalistic progress meter b) makes it easier to add new VMs
to the runner.
