### PR TITLE
Add Spidermonkey to Octane.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ bench-dacapo:
 
 bench-octane:
 	PYTHONPATH=krun/ ${PYTHON} extbench/runoctane.py
-	bin/csv_to_krun_json octane.v8.results
+	bin/csv_to_krun_json -u "`uname -a`" -v V8 -l JavaScript octane.v8.results
+	bin/csv_to_krun_json -u "`uname -a`" -v SpiderMonkey -l JavaScript octane.spidermonkey.results
 
 # XXX target to format results.
 

--- a/extbench/runoctane.py
+++ b/extbench/runoctane.py
@@ -9,7 +9,9 @@ WARMUP_DIR = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
 JAVASCRIPT_VMS = {
     "v8": "sh -c 'cd %s/extbench/octane && LD_LIBRARY_PATH=%s/krun/libkrun %s/work/v8/out/native/d8 run.js'"
-          % (WARMUP_DIR, WARMUP_DIR, WARMUP_DIR)
+          % (WARMUP_DIR, WARMUP_DIR, WARMUP_DIR),
+    "spidermonkey": "sh -c 'cd %s/extbench/octane && %s/work/spidermonkey/js/src/build_OPT.OBJ/dist/bin/js run.js'"
+          % (WARMUP_DIR, WARMUP_DIR)
 }
 
 ITERATIONS = 2000

--- a/patches/openbsd_gcc_patches/patch-gcc_config_i386_openbsdelf_h
+++ b/patches/openbsd_gcc_patches/patch-gcc_config_i386_openbsdelf_h
@@ -1,0 +1,24 @@
+$OpenBSD: patch-gcc_config_i386_openbsdelf_h,v 1.2 2016/07/14 07:22:31 tobiasu Exp $
+--- gcc/config/i386/openbsdelf.h.orig	Thu Jan  2 23:23:26 2014
++++ gcc/config/i386/openbsdelf.h	Fri Jul  8 17:18:50 2016
+@@ -97,14 +97,17 @@ along with GCC; see the file COPYING3.  If not see
+    %{shared:-shared} %{R*} \
+    %{static:-Bstatic} \
+    %{!static:-Bdynamic} \
++   %{rdynamic:-export-dynamic} \
+    %{assert*} \
+    -dynamic-linker /usr/libexec/ld.so"
+ 
+ #undef STARTFILE_SPEC
+-#define STARTFILE_SPEC "\
+-	%{!shared: %{pg:gcrt0%O%s} %{!pg:%{p:gcrt0%O%s} %{!p:crt0%O%s}} \
+-	crtbegin%O%s} %{shared:crtbeginS%O%s}"
+ 
++#define SUBTARGET32_DEFAULT_CPU "i486"
++#define STARTFILE_SPEC "\
++	%{!shared: %{pg:gcrt0%O%s} %{!pg:%{p:gcrt0%O%s} \
++	%{!p:%{!static:crt0%O%s} %{static:%{nopie:crt0%O%s} \
++	%{!nopie:rcrt0%O%s}}}} crtbegin%O%s} %{shared:crtbeginS%O%s}"
+ #undef ENDFILE_SPEC
+ #define ENDFILE_SPEC "%{!shared:crtend%O%s} %{shared:crtendS%O%s}"
+ 

--- a/patches/openbsd_gcc_patches/patch-gcc_config_openbsd_opt
+++ b/patches/openbsd_gcc_patches/patch-gcc_config_openbsd_opt
@@ -1,0 +1,11 @@
+$OpenBSD: patch-gcc_config_openbsd_opt,v 1.1.1.1 2014/06/26 16:30:17 pascal Exp $
+--- gcc/config/openbsd.opt.orig	Sat Jun  8 22:49:21 2013
++++ gcc/config/openbsd.opt	Sat Jun  8 22:49:33 2013
+@@ -32,4 +32,7 @@ Driver
+ pthread
+ Driver
+ 
++rdynamic
++Driver
++
+ ; This comment is to ensure we retain the blank line above.


### PR DESCRIPTION
To get things to build on OpenBSD, we need to import some more GCC patches so
that gcc can deal with -rdynamic.

Note, on bencher6, this currently creates a binary which gets in an endless sequence of:

```
 30072 js       RET   sched_yield 0
 30072 js       CALL  sched_yield()
```

(i.e. doesn't do anything useful). This might be fixed by upgrading to a more recent version of OpenBSD?
