### PR TITLE
Add Graal to the DaCapo runner.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ bench-startup-with-reboots: build-startup build-benchmarks
 
 bench-dacapo:
 	PYTHONPATH=krun/ JAVA_HOME=${JAVA_HOME} ${PYTHON} extbench/rundacapo.py
-	bin/csv_to_krun_json dacapo.hotspot.results
+	bin/csv_to_krun_json -u "`uname -a`" -v Graal -l Java dacapo.graal.results
+	bin/csv_to_krun_json -u "`uname -a`" -v HotSpot -l Java dacapo.hotspot.results
 
 bench-octane:
 	PYTHONPATH=krun/ ${PYTHON} extbench/runoctane.py

--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -3,6 +3,9 @@
 import csv, os, sys, time
 from krun.platform import detect_platform
 from krun.util import run_shell_cmd_bench
+from krun.vm_defs import find_internal_jvmci_java_home
+
+WARMUP_DIR = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
 ITERATIONS = 2000
 PROCESSES = 10
@@ -11,9 +14,13 @@ PROCESSES = 10
 WORKING_BENCHS = ['avrora', 'fop', 'h2', 'jython', 'luindex', 'lusearch',
                   'pmd', 'sunflow', 'tradebeans', 'tradesoap', 'xalan']
 
-JAVA_VMS = {"hotspot" : "$JAVA_HOME/bin/java"}
-
 JAR = os.path.join(os.path.dirname(__file__), "dacapo-9.12-bach.jar")
+
+JVMCI_JAVA_HOME = find_internal_jvmci_java_home('%s/work/jvmci/' % WARMUP_DIR)
+JAVA_VMS = {
+    "graal" : "%s/work/mx/mx --java-home=%s -p %s/work/graal/ -Mjit vm" % (WARMUP_DIR, JVMCI_JAVA_HOME, WARMUP_DIR),
+    "hotspot" : "$JAVA_HOME/bin/java"
+}
 
 def main():
     platform = detect_platform(None, None)


### PR DESCRIPTION
_Not yet ready for merging_ [and, when it is, shouldn't be merged until after #183]

Add Graal to the DaCapo runner so we can compare Graal and HotSpot on the DaCapo benchmark suite.

[The difficulty here was purely trying to work out from `warmup.krun` how to call `mx`!]
