### PR TITLE
First stab at a better Octane runner.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -596,6 +596,7 @@ fetch_octane() {
     cd octane
     git checkout ${OCTANE_V} || exit $?
     patch < ${PATCH_DIR}/octane.diff || exit $?
+    cp ${PATCH_DIR}/octane_run_we.js run_we.js || exit $?
 }
 
 

--- a/extbench/runoctane.py
+++ b/extbench/runoctane.py
@@ -8,9 +8,9 @@ from krun.util import run_shell_cmd_bench
 WARMUP_DIR = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
 JAVASCRIPT_VMS = {
-    "v8": "sh -c 'cd %s/extbench/octane && LD_LIBRARY_PATH=%s/krun/libkrun %s/work/v8/out/native/d8 run.js'"
+    "v8": "sh -c 'cd %s/extbench/octane && LD_LIBRARY_PATH=%s/krun/libkrun %s/work/v8/out/native/d8 run_we.js'"
           % (WARMUP_DIR, WARMUP_DIR, WARMUP_DIR),
-    "spidermonkey": "sh -c 'cd %s/extbench/octane && %s/work/spidermonkey/js/src/build_OPT.OBJ/dist/bin/js run.js'"
+    "spidermonkey": "sh -c 'cd %s/extbench/octane && %s/work/spidermonkey/js/src/build_OPT.OBJ/dist/bin/js run_we.js'"
           % (WARMUP_DIR, WARMUP_DIR)
 }
 

--- a/patches/octane.diff
+++ b/patches/octane.diff
@@ -1,54 +1,3 @@
-diff --git a/base.js b/base.js
-index 9d6e3de..ce04d1b 100644
---- a/base.js
-+++ b/base.js
-@@ -296,39 +296,16 @@ BenchmarkSuite.prototype.RunSingleBenchmark = function(benchmark, data) {
-                         ? config.doDeterministic 
-                         : benchmark.doDeterministic;
- 
--  function Measure(data) {
--    var elapsed = 0;
-+  assert(doDeterministic);
-+
-+  print(benchmark.name);
-+  for (var i = 0; i < 2000; i++) {
-     var start = new Date();
--  
--  // Run either for 1 second or for the number of iterations specified
--  // by minIterations, depending on the config flag doDeterministic.
--    for (var i = 0; (doDeterministic ? 
--      i<benchmark.deterministicIterations : elapsed < 1000); i++) {
-+    for (var j = 0; j < benchmark.deterministicIterations; j++) {
-       benchmark.run();
--      elapsed = new Date() - start;
--    }
--    if (data != null) {
--      data.runs += i;
--      data.elapsed += elapsed;
-     }
--  }
--
--  // Sets up data in order to skip or not the warmup phase.
--  if (!doWarmup && data == null) {
--    data = { runs: 0, elapsed: 0 };
--  }
--
--  if (data == null) {
--    Measure(null);
--    return { runs: 0, elapsed: 0 };
--  } else {
--    Measure(data);
--    // If we've run too few iterations, we continue for another second.
--    if (data.runs < benchmark.minIterations) return data;
--    var usec = (data.elapsed * 1000) / data.runs;
--    var rms = (benchmark.rmsResult != null) ? benchmark.rmsResult() : 0;
--    this.NotifyStep(new BenchmarkResult(benchmark, usec, rms));
--    return null;
-+    var end = new Date();
-+    print("  " + (end - start));
-   }
- }
- 
 diff --git a/pdfjs.js b/pdfjs.js
 index 7953754..2d5584d 100644
 --- a/pdfjs.js
@@ -61,52 +10,15 @@ index 7953754..2d5584d 100644
  }
  
  function tearDownPdfJS() {
-diff --git a/run.js b/run.js
-index d06a6be..395ad56 100644
---- a/run.js
-+++ b/run.js
-@@ -40,37 +40,33 @@ load(base_dir + 'pdfjs.js');
- load(base_dir + 'mandreel.js');
- load(base_dir + 'gbemu-part1.js');
- load(base_dir + 'gbemu-part2.js');
--load(base_dir + 'code-load.js');
-+//load(base_dir + 'code-load.js');
- load(base_dir + 'box2d.js');
--load(base_dir + 'zlib.js');
--load(base_dir + 'zlib-data.js');
-+//load(base_dir + 'zlib.js');
-+//load(base_dir + 'zlib-data.js');
- load(base_dir + 'typescript.js');
- load(base_dir + 'typescript-input.js');
- load(base_dir + 'typescript-compiler.js');
+diff --git a/typescript.js b/typescript.js
+index 2dba23d..10bb8d1 100644
+--- a/typescript.js
++++ b/typescript.js
+@@ -43,7 +43,6 @@ function setupTypescript() {
  
-+
- var success = true;
  
- function PrintResult(name, result) {
--  print(name + ': ' + result);
+ function tearDownTypescript() {
+-  compiler_input = null;
  }
  
  
- function PrintError(name, error) {
--  PrintResult(name, error);
--  success = false;
-+  print("Error: " + name + " " + error);
-+  assert(false);
- }
- 
- 
- function PrintScore(score) {
--  if (success) {
--    print('----');
--    print('Score (version ' + BenchmarkSuite.version + '): ' + score);
--  }
- }
- 
- 
- BenchmarkSuite.config.doWarmup = undefined;
--BenchmarkSuite.config.doDeterministic = undefined;
-+BenchmarkSuite.config.doDeterministic = true;
- 
- BenchmarkSuite.RunSuites({ NotifyResult: PrintResult,
-                            NotifyError: PrintError,

--- a/patches/octane_run_we.js
+++ b/patches/octane_run_we.js
@@ -1,0 +1,51 @@
+load('base.js');
+load('richards.js');
+load('deltablue.js');
+load('crypto.js');
+load('raytrace.js');
+load('earley-boyer.js');
+load('regexp.js');
+load('splay.js');
+load('navier-stokes.js');
+load('pdfjs.js');
+//load('mandreel.js');
+//load('gbemu-part1.js');
+//load('gbemu-part2.js');
+//load('code-load.js');
+//load('box2d.js');
+//load('zlib.js');
+//load('zlib-data.js');
+load('typescript.js');
+load('typescript-input.js');
+load('typescript-compiler.js');
+
+
+function main() {
+  var suites = BenchmarkSuite.suites;
+  for (var i = 0; i < suites.length; i++) {
+    var suite = suites[i];
+    var benchmarks = suite.benchmarks;
+    for (var j = 0; j < benchmarks.length; j++) {
+      var benchmark = benchmarks[j];
+      print(benchmark.name);
+      for (var k = 0; k < 2000; k++) {
+        BenchmarkSuite.ResetRNG();
+        benchmark.Setup();
+        var start = performance.now();
+        // Octane benchmarks consist of a (generally fast) "inner" iteration;
+        // each benchmark then says "running me for
+        // benchmark.deterministicIterations times makes for an outer
+        // iteration". We only care about the outer iterations.
+        for (var l = 0; l < benchmark.deterministicIterations; l++) {
+          benchmark.run();
+        }
+        var elapsed = performance.now() - start;
+        print('  ' + elapsed);
+        benchmark.TearDown();
+      }
+    }
+  }
+}
+
+
+main();


### PR DESCRIPTION
_Not ready for merging until a full test run has completed in a few days time, but ready for review now_

The original Octane runner is written in a convoluted continuation-passing style, for no obvious gain, but at a substantial cost of readability. It also has a couple of features that we don't need. So, first, making things simpler, and removing those features makes our lives a lot better. The new runner also uses a microsecond monotonic timer rather than a millisecond non-monotonic timer, which should give us much better quality data.

[The most important code is probably the new runner in `octane_run_we.js`]
