### PR TITLE
Skip richards on HHVM.

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -130,8 +130,11 @@ SKIP = [
     #"*:V8:*",
     #"*:C:*",
 
-    # XXX: This benchmark is slow *and* crashes
+    # This benchmark is slow *and* crashes
     "fasta:JRubyTruffle:default-ruby",
+
+    # Really very slow.
+    "richards:HHVM:default-php",
 ]
 
 N_EXECUTIONS = 10  # Number of fresh processes.


### PR DESCRIPTION
Skip super slow benchmark.

Skimming the ETAs from the last run, I see none longer than about 70 mins per exec.