### PR TITLE
Summarise categories

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -20,7 +20,7 @@ from matplotlib import gridspec, pyplot
 from matplotlib.collections import LineCollection
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from warmup.krun_results import read_krun_results_file
+from warmup.krun_results import pretty_print_machine, read_krun_results_file
 from warmup.outliers import get_window
 from warmup.plotting import add_margin_to_axes, compute_grid_offsets
 from warmup.plotting import format_yticks_scientific, get_unified_yrange, style_axis
@@ -49,14 +49,6 @@ BENCHMARKS = {
     'spectralnorm':     'Spectral Norm',
     'fannkuch_redux':   'Fannkuch Redux',
     'nbody':            'N-Body',
-}
-
-# Machine names that need to be reformatted.
-MACHINES = {
-    'bencher3': 'Linux1/i7-4790K',
-    'bencher5': 'Linux2/i7-4790',
-    'bencher6': 'OpenBSD/i7-4790',
-    'bencher7': 'ARM',  # this machine has not been set up yet
 }
 
 GRID_MINOR_X_DIVS = 20
@@ -722,10 +714,7 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
         machine = data['audit']['uname'].split(' ')[1]
         if '.' in machine:  # Strip domain names.
             machine = machine.split('.')[0]
-        if machine in MACHINES:
-            machine_name = MACHINES[machine]
-        else:
-            machine_name = machine
+        machine_name = pretty_print_machine(machine)
 
         # Is there instrumentation data with this results file?
         instr_data = False

--- a/bin/table_classification_summaries
+++ b/bin/table_classification_summaries
@@ -44,7 +44,10 @@ def main(data_dcts, window_size, latex_file):
                 for p_exec in xrange(len(data_dcts[machine]['wallclock_times'][key])):
                     categories.append(data_dcts[machine]['classifications'][key][p_exec])
                     last_segment_means.append(data_dcts[machine]['changepoint_means'][key][p_exec][-1])
-                    last_changepoints.append(data_dcts[machine]['changepoints'][key][p_exec][-1])
+                    # Not all process execs have changepoints. However, all
+                    # p_execs will have one or more segment mean.
+                    if data_dcts[machine]['changepoints'][key][p_exec]:
+                        last_changepoints.append(data_dcts[machine]['changepoints'][key][p_exec][-1])
                 # Average all information.
                 most_common_category = _most_common_item_from_list(categories).capitalize()
                 if most_common_category == 'No steady state':
@@ -53,8 +56,11 @@ def main(data_dcts, window_size, latex_file):
                 else:
                     median, error = bootstrap_confidence_interval(last_segment_means)
                     mean_last_segment = format_median_error(median, error)
-                    median, error = bootstrap_confidence_interval(last_changepoints)
-                    mean_last_cpt = format_median_error(median, error, as_integer=True)
+                    if last_changepoints:
+                        median, error = bootstrap_confidence_interval(last_changepoints)
+                        mean_last_cpt = format_median_error(median, error, as_integer=True)
+                    else:  # No changepoints in any process executions.
+                        mean_last_cpt = format_median_error(median, 0, as_integer=True)
                 # Add summary for this benchmark.
                 summary_data[vm_variant][bench] = {'style': most_common_category,
                     'last_cpt': mean_last_cpt, 'last_mean': mean_last_segment}

--- a/bin/table_classification_summaries
+++ b/bin/table_classification_summaries
@@ -1,0 +1,146 @@
+#!/usr/bin/env python2.7
+"""Summarise benchmark classifications.
+Must be run after mark_changepoints_in_json.
+"""
+
+import argparse
+import os
+import os.path
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from warmup.krun_results import pretty_print_variant, read_krun_results_file
+from warmup.latex import preamble, end_document, end_table, escape, section, start_table
+from warmup.statistics import bootstrap_confidence_interval
+
+
+TITLE = 'Summary of benchmark classifications.\nWindow size: %s'
+TABLE_FORMAT = 'llrr'
+TABLE_HEADINGS = '%s & Clasification & Steady iter & Median (s)'
+
+
+def main(data_dcts, window_size, latex_file):
+    summary_data = dict()
+    for machine in data_dcts:
+        keys = sorted(data_dcts[machine]['wallclock_times'].keys())
+        for key in sorted(keys):
+            wallclock_times = data_dcts[machine]['wallclock_times'][key]
+            if len(wallclock_times) == 0:
+                print ('WARNING: Skipping: %s from %s (no executions)' %
+                       (key, machine))
+            elif len(wallclock_times[0]) == 0:
+                print('WARNING: Skipping: %s from %s (benchmark crashed)' %
+                      (key, machine))
+            else:
+                bench, vm, variant = key.split(':')
+                vm_variant = '%s: %s (%s)' % (machine, vm, pretty_print_variant(variant))
+                if vm_variant not in summary_data:
+                    summary_data[vm_variant] = dict()
+                # Get information for all p_execs of this key.
+                categories = list()
+                last_segment_means = list()
+                last_changepoints = list()
+                for p_exec in xrange(len(data_dcts[machine]['wallclock_times'][key])):
+                    categories.append(data_dcts[machine]['classifications'][key][p_exec])
+                    last_segment_means.append(data_dcts[machine]['changepoint_means'][key][p_exec][-1])
+                    last_changepoints.append(data_dcts[machine]['changepoints'][key][p_exec][-1])
+                # Average all information.
+                most_common_category = _most_common_item_from_list(categories)
+                mean_last_segment = format_median_error(*bootstrap_confidence_interval(last_segment_means))
+                mean_last_cpt = format_median_error(*bootstrap_confidence_interval(last_changepoints))
+                # Add summary for this benchmark.
+                summary_data[vm_variant][bench] = {'style': most_common_category,
+                    'last_cpt': mean_last_cpt, 'last_mean': mean_last_segment}
+    # Write out results.
+    write_results_as_latex(summary_data, window_size, latex_file)
+    return
+
+
+def format_median_error(median, error):
+    return '$%.5f\\scriptstyle{\\pm%.6f}$' % (median, error)
+
+def _most_common_item_from_list(list_):
+    return max(set(list_), key=list_.count)
+
+
+def write_results_as_latex(summary, window_size, tex_file):
+    """Write a results file.
+    """
+    print('Writing data to %s.' % tex_file)
+    with open(tex_file, 'w') as fp:
+        fp.write(preamble(TITLE % str(window_size)))
+        for section_heading in sorted(summary):
+            fp.write(section(section_heading))
+            fp.write(start_table(TABLE_FORMAT, TABLE_HEADINGS % 'Benchmark'))
+            for bench in summary[section_heading]:
+                fp.write('%s & %s & %s & %s\\\\ \n' % (escape(bench),
+                         escape(summary[section_heading][bench]['style']),
+                         summary[section_heading][bench]['last_cpt'],
+                         summary[section_heading][bench]['last_mean']))
+            fp.write(end_table())
+            fp.write('\\newpage{}')
+        fp.write(end_document())
+    return
+
+
+def get_data_dictionaries(json_files):
+    """Read a list of BZipped JSON files and return their contents as a
+    dictionaries of machine name -> JSON values.
+    """
+    data_dictionary = dict()
+    window_size = None
+    for filename in json_files:
+        assert os.path.exists(filename), 'File %s does not exist.' % filename
+        print 'Loading: %s' % filename
+        data = read_krun_results_file(filename)
+        if 'classifications' not in data:
+            print 'Please run mark_changepoints_in_json before re-running this script.'
+            sys.exit(1)
+        machine_name = data['audit']['uname'].split(' ')[1]
+        if '.' in machine_name:  # Remove domain, if there is one.
+            machine_name = machine_name.split('.')[0]
+        if machine_name not in data_dictionary:
+            data_dictionary[machine_name] = data
+        else:  # We may have two datasets from the same machine.
+            for outer_key in data:
+                if outer_key == 'audit' or outer_key == 'reboots':
+                    continue
+                elif outer_key == 'window_size':
+                    assert data_dictionary[machine_name][outer_key] == data[outer_key]
+                    continue
+                for key in data[outer_key]:
+                    assert key not in data_dictionary[machine_name][outer_key]
+                    if key not in data_dictionary[machine_name][outer_key]:
+                        data_dictionary[machine_name][outer_key][key] = dict()
+                    data_dictionary[machine_name][outer_key][key] = data[outer_key][key]
+        if window_size is None:
+            window_size = data['window_size']
+        else:
+            assert window_size == data['window_size'], \
+                   ('Cannot summarise categories generated with different' +
+                    ' window sizes.')
+    return window_size, data_dictionary
+
+
+def create_cli_parser():
+    """Create a parser to deal with command line switches.
+    """
+    script = os.path.basename(__file__)
+    description = (('Summarise benchmark classifications stored within a Krun ' +
+                    'results file. Must be run after mark_changepoints_in_json.' +
+                    '\n\nExample usage:\n\n' +
+                    '\t$ python %s -l summary.tex results.json.bz2') % script)
+    parser = argparse.ArgumentParser(description=description,
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('json_files', action='append', nargs='+', default=[],
+                        type=str, help='One or more Krun result files.')
+    parser.add_argument('--outfile', '-o', action='store', dest='latex_file',
+                        type=str, help=('Name of the LaTeX file to write to.'))
+    return parser
+
+
+if __name__ == '__main__':
+    parser = create_cli_parser()
+    options = parser.parse_args()
+    window_size, data_dcts = get_data_dictionaries(options.json_files[0])
+    main(data_dcts, window_size, options.latex_file)

--- a/bin/table_classification_summaries
+++ b/bin/table_classification_summaries
@@ -45,9 +45,13 @@ def main(data_dcts, window_size, latex_file):
                     last_segment_means.append(data_dcts[machine]['changepoint_means'][key][p_exec][-1])
                     last_changepoints.append(data_dcts[machine]['changepoints'][key][p_exec][-1])
                 # Average all information.
-                most_common_category = _most_common_item_from_list(categories)
-                mean_last_segment = format_median_error(*bootstrap_confidence_interval(last_segment_means))
-                mean_last_cpt = format_median_error(*bootstrap_confidence_interval(last_changepoints))
+                most_common_category = _most_common_item_from_list(categories).capitalize()
+                if most_common_category == 'No steady state':
+                    mean_last_segment = ''
+                    mean_last_cpt = ''
+                else:
+                    mean_last_segment = format_median_error(*bootstrap_confidence_interval(last_segment_means))
+                    mean_last_cpt = format_median_error(*bootstrap_confidence_interval(last_changepoints))
                 # Add summary for this benchmark.
                 summary_data[vm_variant][bench] = {'style': most_common_category,
                     'last_cpt': mean_last_cpt, 'last_mean': mean_last_segment}

--- a/bin/table_classification_summaries
+++ b/bin/table_classification_summaries
@@ -10,7 +10,8 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import pretty_print_variant, read_krun_results_file
-from warmup.latex import preamble, end_document, end_table, escape, section, start_table
+from warmup.latex import preamble, end_document, end_table, escape
+from warmup.latex import format_median_error, section, start_table
 from warmup.statistics import bootstrap_confidence_interval
 
 
@@ -50,8 +51,10 @@ def main(data_dcts, window_size, latex_file):
                     mean_last_segment = ''
                     mean_last_cpt = ''
                 else:
-                    mean_last_segment = format_median_error(*bootstrap_confidence_interval(last_segment_means))
-                    mean_last_cpt = format_median_error(*bootstrap_confidence_interval(last_changepoints))
+                    median, error = bootstrap_confidence_interval(last_segment_means)
+                    mean_last_segment = format_median_error(median, error)
+                    median, error = bootstrap_confidence_interval(last_changepoints)
+                    mean_last_cpt = format_median_error(median, error, as_integer=True)
                 # Add summary for this benchmark.
                 summary_data[vm_variant][bench] = {'style': most_common_category,
                     'last_cpt': mean_last_cpt, 'last_mean': mean_last_segment}
@@ -59,9 +62,6 @@ def main(data_dcts, window_size, latex_file):
     write_results_as_latex(summary_data, window_size, latex_file)
     return
 
-
-def format_median_error(median, error):
-    return '$%.5f\\scriptstyle{\\pm%.6f}$' % (median, error)
 
 def _most_common_item_from_list(list_):
     return max(set(list_), key=list_.count)

--- a/bin/table_classification_summaries
+++ b/bin/table_classification_summaries
@@ -9,7 +9,8 @@ import os.path
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from warmup.krun_results import pretty_print_variant, read_krun_results_file
+from warmup.krun_results import pretty_print_machine, pretty_print_variant
+from warmup.krun_results import read_krun_results_file
 from warmup.latex import preamble, end_document, end_table, escape
 from warmup.latex import format_median_error, section, start_table
 from warmup.statistics import bootstrap_confidence_interval
@@ -34,7 +35,8 @@ def main(data_dcts, window_size, latex_file):
                       (key, machine))
             else:
                 bench, vm, variant = key.split(':')
-                vm_variant = '%s: %s (%s)' % (machine, vm, pretty_print_variant(variant))
+                vm_variant = '%s: %s (%s)' % (pretty_print_machine(machine),
+                                              vm, pretty_print_variant(variant))
                 if vm_variant not in summary_data:
                     summary_data[vm_variant] = dict()
                 # Get information for all p_execs of this key.

--- a/bin/table_startup_results
+++ b/bin/table_startup_results
@@ -9,37 +9,13 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import read_krun_results_file
+from warmup.latex import preamble, end_document, end_table, escape
+from warmup.latex import format_median_error, section, start_table
 from warmup.statistics import bootstrap_confidence_interval
 
 TITLE = 'Startup Experiment Results'
-
-__LATEX_HEADER = """
-\documentclass[12pt]{article}
-\usepackage{booktabs}
-\\title{%s}
-\\begin{document}
-\maketitle
-""" % TITLE
-
-__LATEX_SECTION = lambda section: """
-\\section*{%s}
-""" % section
-
-__LATEX_START_TABLE = """
-\\begin{tabular}{lr}
-\\toprule
-VM & Time (secs) \\\\
-\\midrule
-"""
-
-__LATEX_END_TABLE = """
-\\bottomrule
-\\end{tabular}
-"""
-
-__LATEX_FOOTER = """
-\\end{document}
-"""
+TABLE_FORMAT = 'lr'
+TABLE_HEADINGS = 'VM & Time (secs)'
 
 
 def main(data_dcts, latex_file):
@@ -69,14 +45,10 @@ def main(data_dcts, latex_file):
     summary = {'vms':dict(), 'variants':dict()}
     for vm in summary_data['vms']:
         median, error = bootstrap_confidence_interval(summary_data['vms'][vm], confidence=0.99)
-        summary['vms'][vm] = '$%.5f\\scriptstyle{\\pm%.6f}$' % (median, error)
+        summary['vms'][vm] = format_median_error(median, error)
     # Write out results.
     write_results_as_latex(summary, latex_file)
     return
-
-
-def _tex_escape(word):
-    return word.replace('_', '\\_')
 
 
 def write_results_as_latex(summary, tex_filename):
@@ -85,20 +57,14 @@ def write_results_as_latex(summary, tex_filename):
     print('Writing data to %s.' % tex_filename)
     with open(tex_filename, 'w') as fp:
         sections = (('Startup-times', summary)),
-        # Preamble.
-        fp.write(__LATEX_HEADER)
-        # Write out all sections.
+        fp.write(preamble(TITLE))
         for section_heading, summary in sections:
-            # Section heading.
-            fp.write(__LATEX_SECTION(section_heading))
-            # Startup-times per VM.
-            fp.write(__LATEX_START_TABLE)
-            for vm in summary['vms']:
-                fp.write('%s & %s \\\\ \n' %
-                         (_tex_escape(vm), summary['vms'][vm]))
-            fp.write(__LATEX_END_TABLE)
-        # End document.
-        fp.write(__LATEX_FOOTER)
+            fp.write(section(section_heading))
+            fp.write(start_table(TABLE_FORMAT, TABLE_HEADINGS))
+            for vm in sorted(summary['vms']):
+                fp.write('%s & %s \\\\ \n' % (escape(vm), summary['vms'][vm]))
+            fp.write(end_table())
+        fp.write(end_document())
     return
 
 

--- a/warmup/krun_results.py
+++ b/warmup/krun_results.py
@@ -1,6 +1,13 @@
 import bz2
 import json
 
+_MACHINES = {
+    'bencher3': 'Linux1/i7-4790K',
+    'bencher5': 'Linux2/i7-4790',
+    'bencher6': 'OpenBSD/i7-4790',
+    'bencher7': 'ARM',  # this machine has not been set up yet
+}
+
 
 _VARIANTS = {'default-python': 'Python',
              'default-c': 'C',
@@ -9,6 +16,12 @@ _VARIANTS = {'default-python': 'Python',
              'default-ruby': 'Ruby',
              'default-javascript': 'Javascript',
              'default-lua': 'Lua'}
+
+
+def pretty_print_machine(machine):
+    if machine in _MACHINES:
+        return _MACHINES[machine]
+    return machine.capitalize()
 
 
 def pretty_print_variant(language):

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -1,0 +1,61 @@
+__LATEX_PREAMBLE = lambda title: """
+\documentclass[12pt]{article}
+\usepackage{longtable}
+\usepackage{booktabs}
+\\title{%s}
+\\begin{document}
+\maketitle
+""" % title
+
+__LATEX_SECTION = lambda section: """
+\\section*{%s}
+""" % section
+
+__LATEX_START_TABLE = lambda format_, headings: """
+\\begin{center}
+\\begin{longtable}{%s}
+\\toprule
+%s\\\\
+\midrule
+\endfirsthead
+\\toprule
+%s\\\\
+\midrule
+\endhead
+\midrule
+\endfoot
+\\bottomrule
+\endlastfoot
+""" % (format_, headings, headings)
+
+__LATEX_END_TABLE = """
+\end{longtable}
+\end{center}
+"""
+
+__LATEX_END_DOCUMENT = """
+\end{document}
+"""
+
+
+def end_document():
+    return __LATEX_END_DOCUMENT
+
+
+def end_table():
+    return __LATEX_END_TABLE
+
+
+def escape(word):
+    return word.replace('_', '\\_')
+
+def preamble(title):
+    return __LATEX_PREAMBLE(title)
+
+
+def section(heading):
+    return __LATEX_SECTION(heading)
+
+
+def start_table(format_, headings):
+    return __LATEX_START_TABLE(format_, headings)

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -39,8 +39,13 @@ def escape(word):
     return word.replace('_', '\\_')
 
 
-def format_median_error(median, error):
-    return '$%.5f\\scriptstyle{\\pm%.6f}$' % (median, error)
+def format_median_error(median, error, as_integer=False):
+    formatted_text = ''
+    if as_integer:
+        formatted_text = '$%d\\scriptstyle{\\pm%d}$' % (int(median), int(error))
+    else:
+        formatted_text = '$%.5f\\scriptstyle{\\pm%.6f}$' % (median, error)
+    return formatted_text
 
 
 def preamble(title):

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -1,6 +1,5 @@
 __LATEX_PREAMBLE = lambda title: """
 \documentclass[12pt]{article}
-\usepackage{longtable}
 \usepackage{booktabs}
 \\title{%s}
 \\begin{document}
@@ -12,29 +11,19 @@ __LATEX_SECTION = lambda section: """
 """ % section
 
 __LATEX_START_TABLE = lambda format_, headings: """
-\\begin{center}
-\\begin{longtable}{%s}
+\\begin{tabular}{%s}
 \\toprule
-%s\\\\
-\midrule
-\endfirsthead
-\\toprule
-%s\\\\
-\midrule
-\endhead
-\midrule
-\endfoot
-\\bottomrule
-\endlastfoot
-""" % (format_, headings, headings)
+%s \\\\
+\\midrule
+""" % (format_, headings)
 
 __LATEX_END_TABLE = """
-\end{longtable}
-\end{center}
+\\bottomrule
+\\end{tabular}
 """
 
 __LATEX_END_DOCUMENT = """
-\end{document}
+\\end{document}
 """
 
 
@@ -48,6 +37,11 @@ def end_table():
 
 def escape(word):
     return word.replace('_', '\\_')
+
+
+def format_median_error(median, error):
+    return '$%.5f\\scriptstyle{\\pm%.6f}$' % (median, error)
+
 
 def preamble(title):
     return __LATEX_PREAMBLE(title)


### PR DESCRIPTION
This is a first bash at summarising the classification and changepoint information in tables.

The test case is from the dacapo benchmark (which is why there is not much variation in the "styles"). However, the classifications will change soon in a later PR, so for this PR we just want to get the tabulation etc. right.

A couple of notes:
  * Data in the table is averaged over all the process executions for each benchmark. The "style" is the most commonly occurring style for all the process executions in each benchmark. Is this what we want?
  * The table headings are too long, and I'm not sure why they are incorrectly aligned.

As with #217 CIs are not in yet.

Fixes #216 