### PR TITLE
Attempt to fix race condition between network and daemon pre-commands

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -140,21 +140,26 @@ SKIP = [
 N_EXECUTIONS = 10  # Number of fresh processes.
 
 if sys.platform.startswith("linux"):
+    # Assumes systemd is used for init.
     PRE_EXECUTION_CMDS = [
-        "sudo service cron stop",
-        "sudo service atd stop",
-        "sudo service postfix stop",
-        "sudo service networking stop",
+        # Stop network first. If an interface accepts a DHCP lease during one
+        # of the later commands below, it can cause the command to be
+        # "cancelled" by systemd. Bringing the network itself down can fail in
+        # the same way, so keep trying (with sleeps between).
+        "while true; do sudo systemctl stop networking; sleep 5; ping -q -c %s || break; done" % PING_HOST
+        "sudo systemctl stop cron",
+        "sudo systemctl stop atd",
+        "sudo systemctl stop postfix",
     ]
 
     PING_HOST = "bencher2.soft-dev.org"
     POST_EXECUTION_CMDS = [
         # The network doesn't always come up properly on debian. We keep trying
         # until we can ping a host on the network.
-        "while true; do ping -c 3 -q %s && break; sudo service networking stop; sleep 5; sudo service networking start; done" % PING_HOST,
-        "sudo service cron start || true",
-        "sudo service atd start || true",
-        "sudo service postfix start || true",
+        "while true; do ping -c 3 -q %s && break; sudo systemctl stop networking; sleep 5; sudo systemctl start networking; done" % PING_HOST,
+        "sudo systemctl start cron || true",
+        "sudo systemctl start atd || true",
+        "sudo systemctl start postfix || true",
     ]
 elif sys.platform.startswith("openbsd"):
     PRE_EXECUTION_CMDS = [


### PR DESCRIPTION
Bencher3 died mid-experiment in the night.

The reason it dies was because the network interface was coming up at the same time as we ran `service postfix stop`, causing the command to fail and krun to abandon ship.

Current pre commands:
```
PRE_EXECUTION_CMDS = [
        "sudo service cron stop",
        "sudo service atd stop",
        "sudo service postfix stop",
        "sudo service networking stop",
    ]
```

Corresponding systemd log (scroll right):

```
Nov 02 02:53:28 bencher3 sudo[1042]: kruninit : TTY=unknown ; PWD=/home/kruninit/warmup_experiment ; USER=root ; COMMAND=/usr/sbin/service cron stop
Nov 02 02:53:28 bencher3 sudo[1042]: pam_unix(sudo:session): session opened for user root by (uid=0)
Nov 02 02:53:28 bencher3 sudo[1042]: pam_unix(sudo:session): session closed for user root
Nov 02 02:53:28 bencher3 sudo[1062]: kruninit : TTY=unknown ; PWD=/home/kruninit/warmup_experiment ; USER=root ; COMMAND=/usr/sbin/service atd stop
Nov 02 02:53:28 bencher3 sudo[1062]: pam_unix(sudo:session): session opened for user root by (uid=0)
Nov 02 02:53:28 bencher3 sudo[1062]: pam_unix(sudo:session): session closed for user root
Nov 02 02:53:28 bencher3 sudo[1082]: kruninit : TTY=unknown ; PWD=/home/kruninit/warmup_experiment ; USER=root ; COMMAND=/usr/sbin/service postfix stop
Nov 02 02:53:28 bencher3 sudo[1082]: pam_unix(sudo:session): session opened for user root by (uid=0)
Nov 02 02:53:28 bencher3 dhclient[528]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 8
Nov 02 02:53:28 bencher3 ifup[519]: DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 8
Nov 02 02:53:28 bencher3 dhclient[528]: DHCPREQUEST on eth0 to 255.255.255.255 port 67
Nov 02 02:53:28 bencher3 dhclient[528]: DHCPOFFER from 137.73.8.8
Nov 02 02:53:28 bencher3 ifup[519]: DHCPREQUEST on eth0 to 255.255.255.255 port 67
Nov 02 02:53:28 bencher3 ifup[519]: DHCPOFFER from 137.73.8.8
Nov 02 02:53:28 bencher3 dhclient[528]: DHCPACK from 137.73.8.8
Nov 02 02:53:28 bencher3 ifup[519]: DHCPACK from 137.73.8.8
Nov 02 02:53:28 bencher3 dhclient[528]: bound to 137.73.9.137 -- renewal in 289421 seconds.
Nov 02 02:53:28 bencher3 ifup[519]: bound to 137.73.9.137 -- renewal in 289421 seconds.
Nov 02 02:53:28 bencher3 sshd[524]: Received SIGHUP; restarting.
Nov 02 02:53:28 bencher3 sshd[524]: Server listening on 0.0.0.0 port 22.
Nov 02 02:53:28 bencher3 sshd[524]: Server listening on :: port 22.
Nov 02 02:53:28 bencher3 systemd[1]: Unit postfix.service cannot be reloaded because it is inactive.
Nov 02 02:53:28 bencher3 postfix/master[717]: terminating on signal 15
Nov 02 02:53:28 bencher3 sudo[1082]: pam_unix(sudo:session): session closed for user root
Nov 02 02:53:28 bencher3 rc.local[530]: [2016-11-02 02:53:28: ERROR] Command failed: 'sudo service postfix stop'
Nov 02 02:53:28 bencher3 rc.local[530]: stdout:
Nov 02 02:53:28 bencher3 rc.local[530]: stderr:
Nov 02 02:53:28 bencher3 rc.local[530]: Job for postfix.service canceled.
Nov 02 02:53:28 bencher3 postfix[1141]: Stopping Postfix Mail Transport Agent: postfix.
Nov 02 02:53:28 bencher3 ifup[519]: run-parts: /etc/network/if-up.d/postfix exited with return code 1
Nov 02 02:53:28 bencher3 ifup[519]: Failed to bring up eth0.
```

I think the reason the command fails is because when the network comes up, systemd starts dependent services, or HUPs the existing ones, and we can't stop daemons while that happens. Here is a simple way to reproduce the error you see in the log:

```
# systemctl stop postfix & systemctl start postfix
[1] 4119
Job for postfix.service canceled.
[1]+  Exit 1                  systemctl stop postfix
```

But if we stop and start sequentially, no issue:
```
# systemctl stop postfix
# systemctl start postfix
# 
```

Now the fix. If we bring the network down first, then stop our daemons, then there should be no race between DHCP and us bringing services down. Also, be should use `systemctl` not the legacy `service`. I checked on my laptop that `systemctl stop networking` correctly stops the interface, and that `systemctl start networking` brings it back. The latter command takes quite some time to run (5 secs or so), so I suspect it is blocking for DHCP. For good measure added a sleep too.

This is untested. I need a code review before I try it on a bencher.

Thoughts, comments?