### PR TITLE
Startup fixes

### DIFF
--- a/startup_runners/Makefile
+++ b/startup_runners/Makefile
@@ -1,6 +1,7 @@
 PWD != pwd
 C_ITER_RUNNER_CFLAGS = -fPIC -Wall -Wextra -pedantic
 C_ITER_RUNNER_LDFLAGS =
+LIBKRUN_DIR=${PWD}/../krun/libkrun
 
 
 OS != uname -s
@@ -19,16 +20,16 @@ startup_runner.class: startup_runner.java
 
 
 outer_startup_runner_c: outer_startup_runner.c
-	${CC} --std=c99 ${C_ITER_RUNNER_CFLAGS} ${CFLAGS} -L${PWD}/../krun/libkrun \
+	${CC} --std=c99 ${C_ITER_RUNNER_CFLAGS} ${CFLAGS} -L${LIBKRUN_DIR} \
 		${CPPFLAGS} outer_startup_runner.c -I${PWD}/../krun/libkrun \
 		-o outer_startup_runner_c -lkruntime ${C_ITER_RUNNER_LDFLAGS} \
-		${LDFLAGS}
+		${LDFLAGS} -Wl,-rpath=${LIBKRUN_DIR}
 
 startup_runner_c: startup_runner.c
 	${CC} --std=c99 ${C_ITER_RUNNER_CFLAGS} ${CFLAGS} -L${PWD}/../krun/libkrun \
 		${CPPFLAGS} startup_runner.c -I${PWD}/../krun/libkrun \
 		-o startup_runner_c -lkruntime ${C_ITER_RUNNER_LDFLAGS} \
-		${LDFLAGS}
+		${LDFLAGS} -Wl,-rpath=${LIBKRUN_DIR}
 
 clean:
 	rm -f startup_runner_c outer_startup_runner_c startup_runner.class


### PR DESCRIPTION
Hi,

This fixes a buffer overrun and simplifies the code a lot. We also move the clock reading later, thus avoiding reading the majority of printfs. See individual commit messages for more detailed info.

No need to valgrind, as there are no allocations any more.

Output checked to be the same as before (bar emitting aperf before mperf for consistency with elsewhere). Please check carefully.

On OpenBSD (piped to Python json parser to check validity):
```
$ ./outer_startup_runner_c ./startup_runner_c | python -c "import json, sys; j = json.load(sys.stdin); print j"
{u'core_cycle_counts': [], u'wallclock_times': [4702.001296, 4702.002543], u'mperf_counts': [], u'aperf_counts': []}
```

On a bencher3/5, you woud see (hacked on OpenBSD to pretend there are 4 per-core measurements):
```
$ ./outer_startup_runner_c ./startup_runner_c | python -c "import json, sys; j = json.load(sys.stdin); print j"
{u'core_cycle_counts': [[0, 0], [0, 0], [0, 0], [0, 0]], u'wallclock_times': [4690.826458, 4690.827671],
u'mperf_counts': [[0, 0], [0, 0], [0, 0], [0, 0]], u'aperf_counts': [[0, 0], [0, 0], [0, 0], [0, 0]]}
```

OK?