### PR TITLE
Unify x-axis.

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -303,7 +303,7 @@ def draw_process_exec(grid_cell, data, cycles_data, aperf_data, mperf_data,
                 cycles_min = min(min(cycles_data[core][x_bounds[0]:x_bounds[1]]), cycles_min)
                 cycles_max = max(max(cycles_data[core][x_bounds[0]:x_bounds[1]]), cycles_max)
         for core in xrange(len(cycles_data)):  # For each core.
-            cycle_data_narrays.append(numpy.array(cycles_data[core]))
+            cycle_data_narrays.append(numpy.array(cycles_data[core][x_bounds[0]:x_bounds[1]]))
     perf_data_narrays = list()
     if aperf_data and mperf_data:
         for core in xrange(len(aperf_data)):  # For each core.


### PR DESCRIPTION
Matplotlib was complaining that we had subplots sharing x-axes, but whose limits differed. It's becuase we forgot to slice the cycles (I think).

(I know there are deeper issues with xlimits too)