### PR TITLE
Consistent names

### DIFF
--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -18,6 +18,10 @@ from warmup.latex import format_median_error, get_latex_symbol_map
 from warmup.statistics import bootstrap_confidence_interval
 
 
+VM_NAMES_MAP = {
+    "JRubyTruffle": "JRuby+Truffle",
+    "Hotspot": "HotSpot"
+}
 TITLE = 'Summary of benchmark classifications'
 TABLE_FORMAT_START = 'l'
 TABLE_FORMAT_PER_SPLIT = 'p{.5em}p{5pt}crrr'
@@ -205,6 +209,8 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                         row_add = [BLANK_CELL, bench_cell, classification, last_cpt,
                                    time_steady, last_mean]
                     if not row:  # first vm in this row, needs the vm column
+                        if VM_NAMES_MAP.has_key(vm):
+                            vm = VM_NAMES_MAP[vm]
                         row.insert(0, vm)
                     row.extend(row_add)
                     bench_idx += 1

--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -22,6 +22,16 @@ VM_NAMES_MAP = {
     "JRubyTruffle": "JRuby+Truffle",
     "Hotspot": "HotSpot"
 }
+
+BENCHMARK_NAMES_MAP = {
+    "binarytrees": "\\binarytrees",
+    "nbody": "\\nbody",
+    "fannkuch_redux": "\\fannkuch",
+    "richards": "\\richards",
+    "fasta": "\\fasta",
+    "spectralnorm": "\\spectralnorm",
+}
+
 TITLE = 'Summary of benchmark classifications'
 TABLE_FORMAT_START = 'l'
 TABLE_FORMAT_PER_SPLIT = 'p{.5em}p{5pt}crrr'
@@ -200,7 +210,7 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                         else:
                             fudge = 0
                         bench_cell = '\\multirow{%s}{*}{\\rotatebox[origin=c]{90}{%s}}' \
-                            % (num_vms + fudge, escape(bench))
+                            % (num_vms + fudge, BENCHMARK_NAMES_MAP[bench])
                     else:
                         bench_cell = ''
                     if 'inconsistent' in classification:


### PR DESCRIPTION
This PR makes VM and benchmark names consistent in the paper and tables:

![image](https://cloud.githubusercontent.com/assets/20318/20304233/144cf846-ab27-11e6-909a-874f6e51c1a0.png)
