### PR TITLE
Mem fix

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -133,7 +133,13 @@ def get_instr_data(key, machine, instr_dir, pexec_idxs):
             file_ = os.path.join(instr_dir, "%s__%s__%s__%s.json.bz2" %
                                  (bench, vm, variant, pexec_idx))
             print("Loading: %s" % file_)
-            js = read_krun_results_file(file_)
+            try:
+                js = read_krun_results_file(file_)
+            except IOError:
+                print("WARNING: Missing instrumentation data for: %s:%s:%s" % \
+                      (machine, key, pexec_idx))
+                ret.append(None)  # missing instr data
+                continue
             parser = INSTRUMENTATION_PARSERS[vm](js)
             ret.append(parser.chart_data)
             del js  # This can be huge, so eagerly GC it
@@ -535,13 +541,23 @@ def draw_page(is_interactive, executions, cycles_executions,
     # more than one set of instrumentation data (e.g. GC events, JIT
     # compilation, etc.) and each VM instrument must have its own y-range.
     if instr_executions:
-        instr_data_by_instrument = [list() for _ in instr_executions[0]]
+        instr_data_by_instrument = []
         for execution in instr_executions:
-            for index, instrument_data in enumerate(execution):
-                instr_data_by_instrument[index].append(instrument_data.data)
+            if execution is None:
+                continue  # absent instr data for this pexec
+            instr_data_by_instrument = [list() for _ in execution]
+            break
+        for execution in instr_executions:
+            if execution is None:
+                for index in xrange(len(instr_data_by_instrument)):
+                    instr_data_by_instrument[index].append(None)
+            else:
+                for index, instrument_data in enumerate(execution):
+                    instr_data_by_instrument[index].append(instrument_data.data)
         instr_y_ranges = list()
         for chart_data in instr_data_by_instrument:
-            instr_y_ranges.append(get_unified_yrange(chart_data, xlimits_start,
+            chart_data_stripped = [x for x in chart_data if x is not None]
+            instr_y_ranges.append(get_unified_yrange(chart_data_stripped, xlimits_start,
                                                      xlimits_stop, padding=0.02))
     else:
         instr_y_ranges = None

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -122,17 +122,22 @@ EXPORT_SIZE_INCHES = [12, 10]
 DPI = 300
 
 
-def add_instr_data(data_dictionary, key, machine, instr_dir):
-    vm = key.split(':')[1]  # bench, vm, language
+def get_instr_data(key, machine, instr_dir, pexec_idxs):
+    """Get the instrumentation data summary for the specified process execution
+    indexes"""
+
+    bench, vm, variant = key.split(":")
+    ret = []
     if vm in INSTRUMENTATION_PARSERS:
-        files = glob.glob(os.path.join(instr_dir,
-                   key.replace(':', '__') + '__*.json.bz2'))
-        pexec_data = list()
-        for file_ in sorted(files):
-            pexec_data.append(read_krun_results_file(file_))
-        # Merge JSON data from each file and parse.
-        parser = INSTRUMENTATION_PARSERS[vm](merge_instr_data(pexec_data))
-        data_dictionary['instr_data'][key][machine] = parser.chart_data
+        for pexec_idx in pexec_idxs:
+            file_ = os.path.join(instr_dir, "%s__%s__%s__%s.json.bz2" %
+                                 (bench, vm, variant, pexec_idx))
+            print("Loading: %s" % file_)
+            js = read_krun_results_file(file_)
+            parser = INSTRUMENTATION_PARSERS[vm](js)
+            ret.append(parser.chart_data)
+            del js  # This can be huge, so eagerly GC it
+        return ret
 
 
 def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
@@ -737,7 +742,10 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                     else:
                         data_dictionary['cycles_counts'][key][machine] = data['core_cycle_counts'][key]
                         if instr_data:
-                            add_instr_data(data_dictionary, key, machine, instr_dir)
+                            data_dictionary['instr_data'][key][machine] =  \
+                                get_instr_data(
+                                    key, machine, instr_dir,
+                                    xrange(len(data['wallclock_times'][key])))
                         else:
                             data_dictionary['instr_data'][key][machine] = None
             # Construct plot titles for all data in this file.
@@ -828,7 +836,8 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                         if not wallclock_only:
                             data_dictionary['cycles_counts'][key][machine].append(data['core_cycle_counts'][key][p_exec])
                             if instr_data:
-                                add_instr_data(data_dictionary, key, machine, instr_dir)
+                                data_dictionary['instr_data'][key][machine].append(
+                                    get_instr_data(key, machine, instr_dir, [p_exec])[0])
                             else:
                                 data_dictionary['instr_data'][key][machine] = None
 


### PR DESCRIPTION
Fix memory efficiency of plot script, and make the script resilient to missing instr data files.

The memory fix basically just makes it so that only the instrumentation data we need is loaded (a ChartData is for one pexec only now, not all pexecs for a given key) and that only one instr file is loaded in at a time.

memory consumption for the data we have typically bounces between around 4 and 16GB, whereas before it would outright crash.

Tested with and without -b, with and without --onepage, and with missing instr files. Seems ok.

OK?