### PR TITLE
Optional table preamble

### DIFF
--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -13,23 +13,23 @@ from collections import Counter
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import read_krun_results_file
-from warmup.latex import STYLE_SYMBOLS, preamble, end_document, end_table, escape
+from warmup.latex import STYLE_SYMBOLS, preamble, end_document, end_table
 from warmup.latex import format_median_error, get_latex_symbol_map
 from warmup.statistics import bootstrap_confidence_interval
 
 
 VM_NAMES_MAP = {
-    "JRubyTruffle": "JRuby+Truffle",
-    "Hotspot": "HotSpot"
+    'JRubyTruffle': 'JRuby+Truffle',
+    'Hotspot': 'HotSpot'
 }
 
 BENCHMARK_NAMES_MAP = {
-    "binarytrees": "\\binarytrees",
-    "nbody": "\\nbody",
-    "fannkuch_redux": "\\fannkuch",
-    "richards": "\\richards",
-    "fasta": "\\fasta",
-    "spectralnorm": "\\spectralnorm",
+    'binarytrees': '\\binarytrees',
+    'nbody': '\\nbody',
+    'fannkuch_redux': '\\fannkuch',
+    'richards': '\\richards',
+    'fasta': '\\fasta',
+    'spectralnorm': '\\spectralnorm',
 }
 
 TITLE = 'Summary of benchmark classifications'
@@ -42,7 +42,7 @@ TABLE_HEADINGS2 = '&&\\multicolumn{1}{c}{Class.} &\\multicolumn{1}{c}{iter (\#)}
 
 BLANK_CELL = '\\begin{minipage}[c][\\blankheight]{0pt}\\end{minipage}'
 
-def main(data_dcts, window_size, latex_file, num_splits):
+def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
     # machine -> vm -> bench -> summary
     summary_data = dict()
 
@@ -125,10 +125,11 @@ def main(data_dcts, window_size, latex_file, num_splits):
                 'time_to_steady_state':time_to_steady}
     # Write out results.
     write_results_as_latex(machine, list(sorted(all_benchs)), summary_data,
-                           steady_state, latex_file, num_splits)
+                           steady_state, latex_file, num_splits, with_preamble)
 
 
-def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file, num_splits):
+def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
+                           num_splits, with_preamble=False):
     """Write a tex table to disk"""
 
     num_benchmarks = len(all_benchs)
@@ -153,6 +154,10 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
 
     print('Writing data to %s.' % tex_file)
     with open(tex_file, 'w') as fp:
+        if with_preamble:
+            fp.write(preamble(TITLE))
+            fp.write('%s' % get_latex_symbol_map())
+            fp.write('\n\n\n')
         # emit table header
         heads1 = TABLE_HEADINGS_START1 + '&'.join([TABLE_HEADINGS1] * num_splits)
         heads2 = TABLE_HEADINGS_START2 + '&'.join([TABLE_HEADINGS2] * num_splits)
@@ -209,8 +214,12 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                             fudge = 1
                         else:
                             fudge = 0
-                        bench_cell = '\\multirow{%s}{*}{\\rotatebox[origin=c]{90}{%s}}' \
-                            % (num_vms + fudge, BENCHMARK_NAMES_MAP[bench])
+                        try:
+                            bench_cell = '\\multirow{%s}{*}{\\rotatebox[origin=c]{90}{%s}}' \
+                                % (num_vms + fudge, BENCHMARK_NAMES_MAP[bench])
+                        except KeyError:
+                            bench_cell = '\\multirow{%s}{*}{\\rotatebox[origin=c]{90}{%s}}' \
+                                % (num_vms + fudge, bench)
                     else:
                         bench_cell = ''
                     if 'inconsistent' in classification:
@@ -236,6 +245,8 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                 fp.write('\midrule\n')
             split_row_idx += 1
         fp.write(end_table())
+        if with_preamble:
+            fp.write(end_document())
     return
 
 
@@ -291,11 +302,14 @@ def create_cli_parser():
     parser.add_argument('json_files', action='append', nargs='+', default=[],
                         type=str, help='One or more Krun result files.')
     parser.add_argument('--outfile', '-o', action='store', dest='latex_file',
-                        type=str, help=('Name of the LaTeX file to write to.'),
+                        type=str, help='Name of the LaTeX file to write to.',
                         required=True)
     parser.add_argument('--num_splits', '-s', action='store',
-                        type=int, help=('Number of horizontal splits.'),
+                        type=int, help='Number of horizontal splits.',
                         default=1)
+    parser.add_argument('--with-preamble', action='store_true',
+                        dest='with_preamble', default=False,
+                        help='Write out a whole LaTeX article (not just the table).')
     return parser
 
 
@@ -303,4 +317,7 @@ if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
     steady_state, data_dcts = get_data_dictionaries(options.json_files[0])
-    main(data_dcts, steady_state, options.latex_file, options.num_splits)
+    if options.with_preamble:
+        print 'Writing out full document, with preamble.'
+    main(data_dcts, steady_state, options.latex_file, options.num_splits,
+         options.with_preamble)

--- a/bin/table_classification_summaries_others
+++ b/bin/table_classification_summaries_others
@@ -14,7 +14,7 @@ from collections import Counter
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import read_krun_results_file
 from warmup.latex import STYLE_SYMBOLS, preamble, end_document, end_table, escape
-from warmup.latex import format_median_error, get_latex_symbol_map
+from warmup.latex import get_latex_symbol_map, format_median_error
 from warmup.statistics import bootstrap_confidence_interval
 
 
@@ -30,7 +30,7 @@ BLANK_CELL = '\\begin{minipage}[c][\\blankheight]{0pt}\\end{minipage}'
 
 SKIP_OUTER_KEYS = ['audit', 'reboots', 'window_size']
 
-def main(data_dcts, window_size, latex_file, num_splits):
+def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
     # machine -> vm -> bench -> summary
     summary_data = dict()
 
@@ -113,10 +113,11 @@ def main(data_dcts, window_size, latex_file, num_splits):
                 'time_to_steady_state':time_to_steady}
     # Write out results.
     write_results_as_latex(machine, list(sorted(all_benchs)), summary_data,
-                           steady_state, latex_file, num_splits)
+                           steady_state, latex_file, num_splits, with_preamble)
 
 
-def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file, num_splits):
+def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
+                           num_splits, with_preamble=False):
     """Write a tex table to disk"""
 
     num_benchmarks = len(all_benchs)
@@ -142,6 +143,10 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
 
     print('Writing data to %s.' % tex_file)
     with open(tex_file, 'w') as fp:
+        if with_preamble:
+            fp.write(preamble(TITLE))
+            fp.write('%s' % get_latex_symbol_map())
+            fp.write('\n\n\n')
         # emit table header
         heads1 = TABLE_HEADINGS_START1 + '&'.join([TABLE_HEADINGS1] * num_splits)
         heads2 = TABLE_HEADINGS_START2 + '&'.join([TABLE_HEADINGS2] * num_splits)
@@ -222,6 +227,8 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                 fp.write('\midrule\n')
             split_row_idx += 1
         fp.write(end_table())
+        if with_preamble:
+            fp.write(end_document())
     return
 
 
@@ -277,11 +284,14 @@ def create_cli_parser():
     parser.add_argument('json_files', action='append', nargs='+', default=[],
                         type=str, help='One or more Krun result files.')
     parser.add_argument('--outfile', '-o', action='store', dest='latex_file',
-                        type=str, help=('Name of the LaTeX file to write to.'),
+                        type=str, help='Name of the LaTeX file to write to.',
                         required=True)
     parser.add_argument('--num_splits', '-s', action='store',
-                        type=int, help=('Number of horizontal splits.'),
+                        type=int, help='Number of horizontal splits.',
                         default=1)
+    parser.add_argument('--with-preamble', action='store_true',
+                        dest='with_preamble', default=False,
+                        help='Write out a whole LaTeX article (not just the table).')
     return parser
 
 
@@ -289,4 +299,8 @@ if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
     steady_state, data_dcts = get_data_dictionaries(options.json_files[0])
-    main(data_dcts, steady_state, options.latex_file, options.num_splits)
+    if options.with_preamble:
+        print 'Writing out full document, with preamble.'
+    main(data_dcts, steady_state, options.latex_file, options.num_splits,
+         options.with_preamble)
+

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -20,6 +20,14 @@ def get_latex_symbol_map(prefix='\\textbf{Symbol key:} '):
 
 
 __MACROS = """
+\\newlength{\\blankheight}
+\\settototalheight{\\blankheight}{
+$\\begin{array}{rr}
+\\scriptstyle{0.16} \\\\[-6pt]
+\\scriptscriptstyle{\\pm0.000}
+\end{array}$
+}
+
 \\DeclareRobustCommand{\\flatc}{%
 \\setlength{\\sparklinethickness}{0.4pt}%
 \\begin{sparkline}{1.5}
@@ -80,6 +88,8 @@ __LATEX_PREAMBLE = lambda title, doc_opts=DEFAULT_DOCOPTS: """
 \usepackage{amssymb}
 \usepackage{booktabs}
 \usepackage{calc}
+\usepackage{mathtools}
+\usepackage{multicol}
 \usepackage{multirow}
 \usepackage{rotating}
 \usepackage{sparklines}


### PR DESCRIPTION
This PR adds a new CLI option `--with-preamble` to the table scripts. 

By default, the output of the script will be (as before) just the table, suitable for copying and pasting into a larger document. 

With `--with-preamble` on, a full latex document will be written out, with a preamble, `\begin{document}` and `\end{document}`.