### PR TITLE
Report inconsistent benchmarks with steady states

### DIFF
--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -153,6 +153,8 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
             fp.write(preamble(TITLE))
             fp.write('%s' % get_latex_symbol_map())
             fp.write('\n\n\n')
+            fp.write('\\begin{table*}[t]\n')
+            fp.write('\\centering\n')
         # emit table header
         heads1 = TABLE_HEADINGS_START1 + '&'.join([TABLE_HEADINGS1] * num_splits)
         heads2 = TABLE_HEADINGS_START2 + '&'.join([TABLE_HEADINGS2] * num_splits)
@@ -235,6 +237,7 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
             split_row_idx += 1
         fp.write(end_table())
         if with_preamble:
+            fp.write('\\end{table*}\n')
             fp.write(end_document())
     return
 

--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -111,7 +111,7 @@ def main(data_dcts, window_size, latex_file, with_preamble=False):
                     median_t, error_t = bootstrap_confidence_interval(time_to_steadys)
                     time_to_steady = format_median_error(median_t, error_t, brief=True)
                 else:  # No changepoints in any process executions.
-                    mean_last_cpt = format_median_error(median, 0, as_integer=True)
+                    mean_last_cpt = format_median_error(0, 0, as_integer=True)
                     time_to_steady = ''
             # Add summary for this benchmark.
             summary_data[vm][bench] = {'style': reported_category,

--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -33,8 +33,7 @@ BENCHMARK_NAMES_MAP = {
 }
 
 TITLE = 'Summary of benchmark classifications'
-TABLE_FORMAT_START = 'l'
-TABLE_FORMAT_PER_SPLIT = 'p{.5em}p{5pt}crrr'
+TABLE_FORMAT = 'll@{\hspace{0cm}}lp{5pt}r@{\hspace{0cm}}r@{\hspace{0cm}}r@{\hspace{0cm}}l@{\hspace{.3cm}}lp{5pt}r@{\hspace{0cm}}r@{\hspace{0cm}}r'
 TABLE_HEADINGS_START1 = '\\multicolumn{1}{c}{\\multirow{2}{*}{}}&'
 TABLE_HEADINGS_START2 = '&'
 TABLE_HEADINGS1 = '&&\\multicolumn{1}{c}{} &\\multicolumn{1}{c}{Steady}&\\multicolumn{1}{c}{Steady}&\\multicolumn{1}{c}{Steady}'
@@ -42,7 +41,7 @@ TABLE_HEADINGS2 = '&&\\multicolumn{1}{c}{Class.} &\\multicolumn{1}{c}{iter (\#)}
 
 BLANK_CELL = '\\begin{minipage}[c][\\blankheight]{0pt}\\end{minipage}'
 
-def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
+def main(data_dcts, window_size, latex_file, with_preamble=False):
     # machine -> vm -> bench -> summary
     summary_data = dict()
 
@@ -120,12 +119,13 @@ def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
                 'time_to_steady_state':time_to_steady}
     # Write out results.
     write_results_as_latex(machine, list(sorted(all_benchs)), summary_data,
-                           steady_state, latex_file, num_splits, with_preamble)
+                           steady_state, latex_file, with_preamble)
 
 
 def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
-                           num_splits, with_preamble=False):
+                           with_preamble=False):
     """Write a tex table to disk"""
+    num_splits = 2  # 2 sets of VMs in each table
 
     num_benchmarks = len(all_benchs)
     num_vms = len(summary)
@@ -159,7 +159,6 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
         heads1 = TABLE_HEADINGS_START1 + '&'.join([TABLE_HEADINGS1] * num_splits)
         heads2 = TABLE_HEADINGS_START2 + '&'.join([TABLE_HEADINGS2] * num_splits)
         heads = '%s\\\\%s' % (heads1, heads2)
-        fmt = TABLE_FORMAT_START + TABLE_FORMAT_PER_SPLIT * num_splits
         fp.write(\
 """
 {
@@ -167,7 +166,7 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
 \\toprule
 %s \\\\
 \\midrule
-""" % (fmt, heads))
+""" % (TABLE_FORMAT, heads))
 
         split_row_idx = 0
         for row_benchs in zip(*splits):
@@ -296,9 +295,6 @@ def create_cli_parser():
     parser.add_argument('--outfile', '-o', action='store', dest='latex_file',
                         type=str, help='Name of the LaTeX file to write to.',
                         required=True)
-    parser.add_argument('--num_splits', '-s', action='store',
-                        type=int, help='Number of horizontal splits.',
-                        default=1)
     parser.add_argument('--with-preamble', action='store_true',
                         dest='with_preamble', default=False,
                         help='Write out a whole LaTeX article (not just the table).')
@@ -311,5 +307,4 @@ if __name__ == '__main__':
     steady_state, data_dcts = get_data_dictionaries(options.json_files[0])
     if options.with_preamble:
         print 'Writing out full document, with preamble.'
-    main(data_dcts, steady_state, options.latex_file, options.num_splits,
-         options.with_preamble)
+    main(data_dcts, steady_state, options.latex_file, options.with_preamble)

--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -99,8 +99,7 @@ def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
                     cat_counts.append('$%d$%s' % (occurences, STYLE_SYMBOLS[category]))
                 reported_category += ' \\scriptsize(%s)' % ', '.join(cat_counts)
 
-            if (reported_category == STYLE_SYMBOLS['no steady state'] or
-                reported_category.startswith(STYLE_SYMBOLS['inconsistent'])):
+            if STYLE_SYMBOLS['no steady state'] in reported_category:
                 mean_last_segment = ''
                 mean_last_cpt = ''
                 time_to_steady = ''
@@ -189,13 +188,10 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                         time_steady = this_summary['time_to_steady_state']
                         last_mean = this_summary['last_mean']
 
-                        if 'inconsistent' in classification:
-                            classification = '\\multicolumn{4}{l}{%s}' % classification
-                        else:
-                            classification = '\\multicolumn{1}{l}{%s}' % classification
-                            if 'flatc' in classification:
-                                last_cpt = BLANK_CELL
-                                time_steady = BLANK_CELL
+                        classification = '\\multicolumn{1}{l}{%s}' % classification
+                        if classification == STYLE_SYMBOLS['flat']:
+                            last_cpt = BLANK_CELL
+                            time_steady = BLANK_CELL
                     if last_cpt == '':
                         last_cpt = BLANK_CELL
                     if time_steady == '':
@@ -218,11 +214,8 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                                 % (num_vms + fudge, bench)
                     else:
                         bench_cell = ''
-                    if 'inconsistent' in classification:
-                        row_add = [BLANK_CELL, bench_cell, classification]
-                    else:
-                        row_add = [BLANK_CELL, bench_cell, classification, last_cpt,
-                                   time_steady, last_mean]
+                    row_add = [BLANK_CELL, bench_cell, classification, last_cpt,
+                               time_steady, last_mean]
                     if not row:  # first vm in this row, needs the vm column
                         if VM_NAMES_MAP.has_key(vm):
                             row.insert(0, VM_NAMES_MAP[vm])

--- a/bin/table_classification_summaries_others
+++ b/bin/table_classification_summaries_others
@@ -142,6 +142,8 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
             fp.write(preamble(TITLE))
             fp.write('%s' % get_latex_symbol_map())
             fp.write('\n\n\n')
+            fp.write('\\begin{table*}[t]\n')
+            fp.write('\\centering\n')
         # emit table header
         heads1 = TABLE_HEADINGS_START1 + '&'.join([TABLE_HEADINGS1] * num_splits)
         heads2 = TABLE_HEADINGS_START2 + '&'.join([TABLE_HEADINGS2] * num_splits)
@@ -225,6 +227,7 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
             split_row_idx += 1
         fp.write(end_table())
         if with_preamble:
+            fp.write('\\end{table*}\n')
             fp.write(end_document())
     return
 

--- a/bin/table_classification_summaries_others
+++ b/bin/table_classification_summaries_others
@@ -87,8 +87,7 @@ def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
                     cat_counts.append('$%d$%s' % (occurences, STYLE_SYMBOLS[category]))
                 reported_category += ' \\scriptsize(%s)' % ', '.join(cat_counts)
 
-            if (reported_category == STYLE_SYMBOLS['no steady state'] or
-                reported_category.startswith(STYLE_SYMBOLS['inconsistent'])):
+            if STYLE_SYMBOLS['no steady state'] in reported_category:
                 mean_last_segment = ''
                 mean_last_cpt = ''
                 time_to_steady = ''
@@ -178,7 +177,8 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                         time_steady = this_summary['time_to_steady_state']
                         last_mean = this_summary['last_mean']
 
-                        if 'inconsistent' in classification:
+                        if (STYLE_SYMBOLS['inconsistent'] in classification and
+                              STYLE_SYMBOLS['no steady state'] in classification):
                             classification = '\\multicolumn{4}{l}{%s}' % classification
                         else:
                             classification = '\\multicolumn{1}{l}{%s}' % classification
@@ -203,7 +203,8 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
                             % (num_benchmarks + fudge, vm)
                     else:
                         vm_cell = ''
-                    if 'inconsistent' in classification:
+                    if (STYLE_SYMBOLS['inconsistent'] in classification and
+                         STYLE_SYMBOLS['no steady state'] in classification):
                         row_add = [BLANK_CELL, vm_cell, classification]
                     else:
                         row_add = [BLANK_CELL, vm_cell, classification, last_cpt,

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -102,24 +102,29 @@ $\\begin{array}{rr}
 \\end{sparkline}\\xspace}
 """
 
-DEFAULT_DOCOPTS = '12pt, a4paper'
+DEFAULT_DOCOPTS = '10pt, a4paper'
 
 __LATEX_PREAMBLE = lambda title, doc_opts=DEFAULT_DOCOPTS: """
-\documentclass[%s]{article}
-\usepackage{amsmath}
-\usepackage{amssymb}
-\usepackage{booktabs}
-\usepackage{calc}
-\usepackage{mathtools}
-\usepackage{multicol}
-\usepackage{multirow}
-\usepackage{rotating}
-\usepackage{sparklines}
-\usepackage{xspace}
+\\documentclass[%s]{article}
+\\usepackage{amsmath}
+\\usepackage{amssymb}
+\\usepackage{booktabs}
+\\usepackage{calc}
+\\usepackage[margin=1.0cm]{geometry}
+\\usepackage{mathtools}
+\\usepackage{multicol}
+\\usepackage{multirow}
+\\usepackage{rotating}
+\\usepackage{sparklines}
+\\usepackage{xspace}
+
+
 %s
 \\title{%s}
 \\begin{document}
-\maketitle
+\\maketitle
+\\thispagestyle{empty}
+\\pagestyle{empty}
 """ % (doc_opts, __MACROS, title)
 
 __LATEX_SECTION = lambda section: """

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -20,6 +20,9 @@ def get_latex_symbol_map(prefix='\\textbf{Symbol key:} '):
 
 
 __MACROS = """
+%
+% blankheight.
+%
 \\newlength{\\blankheight}
 \\settototalheight{\\blankheight}{
 $\\begin{array}{rr}
@@ -28,6 +31,25 @@ $\\begin{array}{rr}
 \end{array}$
 }
 
+
+%
+% Benchmark names.
+%
+\\newcommand{\\binarytrees}{\\emph{binary trees}\\xspace}
+\\newcommand{\\richards}{\\emph{Richards}\\xspace}
+\\newcommand{\\spectralnorm}{\\emph{spectralnorm}\\xspace}
+\\newcommand{\\nbody}{\\emph{n-body}\\xspace}
+\\newcommand{\\fasta}{\\emph{fasta}\\xspace}
+\\newcommand{\\fannkuch}{\\emph{fannkuch redux}\\xspace}
+\\newcommand{\\bencherthree}{Linux$_\\mathrm{4790K}$\\xspace}
+\\newcommand{\\bencherfive}{Linux$_\\mathrm{4790}$\\xspace}
+\\newcommand{\\benchersix}{OpenBSD$_\\mathrm{4790}$\\xspace}
+\\newcommand{\\bencherseven}{Linux$_\\mathrm{E3-1240v5}$\\xspace}
+
+
+%
+% Sparklines.
+%
 \\DeclareRobustCommand{\\flatc}{%
 \\setlength{\\sparklinethickness}{0.4pt}%
 \\begin{sparkline}{1.5}


### PR DESCRIPTION
This is the latest output of the table_main script on the b3 data (you will have to rename the files):

  * Table for paper: [bencher3.table.txt](https://github.com/softdevteam/warmup_experiment/files/628374/bencher3.table.txt)
  * Full document generated by `--with-preamble`: [b3_table.tex.txt](https://github.com/softdevteam/warmup_experiment/files/628378/b3_table.tex.txt)

The full document does not correctly centre the table, I think this belies a deeper problem, and maybe the table header still isn't correct (it looks like it has two too many columns, but LaTeX fails if you remove a couple!
