### PR TITLE
Automatically compute iterations which should be placed in an inset

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -100,6 +100,8 @@ PERF_YTICK_FORMAT = '%.1f'
 INSET_DEFAULT_WIDTH = 0.4
 INSET_DEFAULT_HEIGHT = 0.25
 INSET_PADDING = 0.035
+INSET_MIN_ITERS = 50
+INSET_MAX_ITERS = 150
 INSET_TICK_FONTSIZE = 8
 
 # Default (PDF) font sizes
@@ -641,36 +643,62 @@ def draw_page(is_interactive, executions, cycles_executions,
 
     # Draw an inset, if required. This MUST be done after adjusting subplots,
     # so that we can calculate the correct bounding box for the inset.
+    def collide_rect((left, bottom, width, height), x_bounds, y_bounds, data):
+        size = x_bounds[1] - x_bounds[0]
+        x_left, x_right = int(size * left), int(size * (left + width))
+        y_low = (y_bounds[1] - y_bounds[0]) * bottom + y_bounds[0]
+        maximum_y = max(data[x_left:x_right])
+        if maximum_y > y_low:  # Largest datum > bottom of inset.
+            return True
+        return False
     if inset:
         index, row, col = 0, 0, 0
         while index < n_execs:
             axis = wallclock_axes[index]
-            inset_rect = (1.0 - INSET_DEFAULT_WIDTH - INSET_PADDING,
-                          1.0 - INSET_DEFAULT_HEIGHT - INSET_PADDING,
-                          INSET_DEFAULT_WIDTH, INSET_DEFAULT_HEIGHT)
-            inset = add_inset_to_axis(fig, axis, inset_rect)
-            inset.set_ylim([y_min, y_max])  # Same scale as larger subplot.
-            inset.grid(False)  # Too many lines and y-ticks looks very messy.
-            inset.set_yticks([y_min, y_min + ((y_max - y_min) / 2.0), y_max])
-            inset.yaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter(YTICK_FORMAT))
-            inset.xaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
-            inset.yaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
-            # Which iterations go in the inset? By default the first 2.5%.
-            one_pc = len(executions[index][x_bounds[0]:x_bounds[1]]) / 100.0  # 1% of the iterations.
-            inset_xlimit = (0, int(one_pc * 2.5))
-            # If all the changepoints occur at the start of the process exec,
-            # include them all and a few extra executions.
-            if changepoints and changepoints[index]:
-                if changepoints[index][x_bounds[0]:x_bounds[1]][-1] <= int(one_pc * 5.0):
-                    inset_xlimit = (0, (changepoints[index][x_bounds[0]:x_bounds[1]][-1]
-                                        + int(one_pc * 2.0)))
-            # Clamp the extent of the inset.
-            if inset_xlimit[1] > 150:
-                inset_xlimit = (0, 150)
-            inset.plot(range(*inset_xlimit),  # Plot subset of the data.
-                       executions[index][inset_xlimit[0]:inset_xlimit[1]],
-                       color=LINE_COLOUR, linewidth=PLOT_LINE_WIDTH,
-                       zorder=ZORDER_DATA)
+            # Find a rectangle that will not collide with data.
+            inset_collides = False
+            for fudge in (0.0, 0.1, 0.2):
+                rect = (1.0 - INSET_DEFAULT_WIDTH - fudge - INSET_PADDING,
+                      1.0 - INSET_DEFAULT_HEIGHT - fudge - INSET_PADDING,
+                      INSET_DEFAULT_WIDTH - fudge, INSET_DEFAULT_HEIGHT - fudge)
+                inset_collides = collide_rect(rect, x_bounds, (y_min, y_max),
+                                              executions[index][x_bounds[0]:x_bounds[1]])
+                if not inset_collides:
+                    break
+            if not inset_collides:
+                # Create and style the inset.
+                inset = add_inset_to_axis(fig, axis, rect)
+                inset.set_ylim([y_min, y_max])  # Same scale as larger subplot.
+                inset.grid(False)
+                inset.set_yticks([y_min, y_min + ((y_max - y_min) / 2.0), y_max])
+                inset.yaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter(YTICK_FORMAT))
+                inset.xaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
+                inset.yaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
+                # Which iterations go in the inset? By default the first 2.5%.
+                one_pc = len(executions[index][x_bounds[0]:x_bounds[1]]) / 100.0  # 1% of the iterations.
+                inset_xlimit = (0, int(one_pc * 2.5))
+                # If all the changepoints occur at the start of the process exec,
+                # include them all and a few extra executions.
+                if changepoints and changepoints[index]:
+                    if changepoints[index][x_bounds[0]:x_bounds[1]][-1] <= int(one_pc * 5.0):
+                        inset_xlimit = (0, (changepoints[index][x_bounds[0]:x_bounds[1]][-1]
+                                            + int(one_pc * 2.0)))
+                # Clamp the extent of the inset.
+                if inset_xlimit[1] < INSET_MIN_ITERS:
+                    inset_xlimit = (0, min(INSET_MIN_ITERS, x_bounds[1] - x_bounds[0]))
+                elif inset_xlimit[1] > INSET_MAX_ITERS:
+                    inset_xlimit = (0, min(INSET_MAX_ITERS, x_bounds[1] - x_bounds[0]))
+                inset.set_xlim(inset_xlimit[0], inset_xlimit[1], auto=False)
+                # Plot a subset of the data on the inset.
+                start, end = x_bounds[0] + inset_xlimit[0], x_bounds[0] + inset_xlimit[1] + 1
+                inset.plot(range(inset_xlimit[0], inset_xlimit[1] + 1),
+                           executions[index][start:end], color=LINE_COLOUR,
+                           linewidth=PLOT_LINE_WIDTH, zorder=ZORDER_DATA)
+                pyplot.draw()  # Force xticklabels to be drawn.
+                labels = [label.get_text() for label in inset.get_xticklabels()]
+                if not labels[-1]:  # Sometimes the last label is empty.
+                    labels = labels[0:-1]
+                inset.set_xticklabels([str(int(label) + x_bounds[0]) for label in labels])
             col += 1
             if col == MAX_SUBPLOTS_PER_ROW:
                 col = 0

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -97,7 +97,9 @@ PERF_YRANGE = (0.0, 1.2)
 PERF_YTICK_FORMAT = '%.1f'
 
 # Inset placement (left, bottom, width, height) relative to subplot axis.
-INSET_RECT = (0.675, 0.82, 0.3, 0.15)
+INSET_DEFAULT_WIDTH = 0.4
+INSET_DEFAULT_HEIGHT = 0.25
+INSET_PADDING = 0.035
 INSET_TICK_FONTSIZE = 8
 
 # Default (PDF) font sizes
@@ -147,7 +149,7 @@ def get_instr_data(key, machine, instr_dir, pexec_idxs):
 
 def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
          xlimits, with_outliers, unique_outliers, changepoints, changepoint_means,
-         median=False, tukey=False, inset_xlimit=None, one_page=False,
+         median=False, tukey=False, inset=False, one_page=False,
          legend_off=True, core_cycles=(0,1,2,3), cycles_ylimits=None):
     """Determine which plots to put on each page of output.
     Plot all data.
@@ -280,7 +282,7 @@ def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
                                          window_size, xlimits, outliers,
                                          unique, common, changepoints,
                                          changepoint_means, median, tukey,
-                                         inset_xlimit, legend_off, core_cycles,
+                                         inset, legend_off, core_cycles,
                                          cycles_ylimits)
             if rv is not None:
                 fig, export_size = rv
@@ -540,7 +542,7 @@ def draw_process_exec(grid_cell, data, cycles_data,
 def draw_page(is_interactive, executions, cycles_executions,
               instr_executions, titles, window_size, xlimits,
               outliers, unique, common, changepoints, changepoint_means, median,
-              tukey, inset_xlimit=100, legend_off=True, core_cycles=(0,1,2,3),
+              tukey, inset=False, legend_off=True, core_cycles=(0,1,2,3),
               cycles_ylimits=None):
     """Plot a page of benchmarks.
     """
@@ -639,17 +641,32 @@ def draw_page(is_interactive, executions, cycles_executions,
 
     # Draw an inset, if required. This MUST be done after adjusting subplots,
     # so that we can calculate the correct bounding box for the inset.
-    if inset_xlimit is not None:
+    if inset:
         index, row, col = 0, 0, 0
         while index < n_execs:
             axis = wallclock_axes[index]
-            inset = add_inset_to_axis(fig, axis, INSET_RECT)
+            inset_rect = (1.0 - INSET_DEFAULT_WIDTH - INSET_PADDING,
+                          1.0 - INSET_DEFAULT_HEIGHT - INSET_PADDING,
+                          INSET_DEFAULT_WIDTH, INSET_DEFAULT_HEIGHT)
+            inset = add_inset_to_axis(fig, axis, inset_rect)
             inset.set_ylim([y_min, y_max])  # Same scale as larger subplot.
             inset.grid(False)  # Too many lines and y-ticks looks very messy.
             inset.set_yticks([y_min, y_min + ((y_max - y_min) / 2.0), y_max])
             inset.yaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter(YTICK_FORMAT))
             inset.xaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
             inset.yaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
+            # Which iterations go in the inset? By default the first 2.5%.
+            one_pc = len(executions[index][x_bounds[0]:x_bounds[1]]) / 100.0  # 1% of the iterations.
+            inset_xlimit = (0, int(one_pc * 2.5))
+            # If all the changepoints occur at the start of the process exec,
+            # include them all and a few extra executions.
+            if changepoints and changepoints[index]:
+                if changepoints[index][x_bounds[0]:x_bounds[1]][-1] <= int(one_pc * 5.0):
+                    inset_xlimit = (0, (changepoints[index][x_bounds[0]:x_bounds[1]][-1]
+                                        + int(one_pc * 2.0)))
+            # Clamp the extent of the inset.
+            if inset_xlimit[1] > 150:
+                inset_xlimit = (0, 150)
             inset.plot(range(*inset_xlimit),  # Plot subset of the data.
                        executions[index][inset_xlimit[0]:inset_xlimit[1]],
                        color=LINE_COLOUR, linewidth=PLOT_LINE_WIDTH,
@@ -1039,18 +1056,14 @@ def create_cli_parser():
                              "'start,end'. Samples start from 0. e.g. "
                              "'-x 100,130' will show samples in the range "
                              "100 to 130.")
-    parser.add_argument('--inset-xlimits',
-                        action='store',
-                        dest='inset_xlimits',
-                        default=None,
-                        type=str,
-                        metavar='LIMIT',
+    parser.add_argument('--inset',
+                        action='store_true',
+                        dest='inset',
+                        default=False,
                         help='Place a small chart plotting a small number of '
                              'values in an inset inside each plot. This is '
                              'intended to make it easier to see detail during '
-                             'the warm-up phase of each benchmark. LIMIT '
-                             'should be a 2-tuple, e.g. 0,100 would show '
-                             'the fist 100 iterations in the inset.')
+                             'the warm-up phase of each benchmark.')
     parser.add_argument('--with-outliers',
                         action='store_true',
                         dest='outliers',
@@ -1172,11 +1185,6 @@ if __name__ == '__main__':
                             options.outliers, options.unique_outliers,
                             options.changepoints or options.changepoint_means)
 
-    inset_xlimits = None
-    if options.inset_xlimits is not None:
-        inset_xlimits = (int(options.inset_xlimits.split(',')[0]),
-                         int(options.inset_xlimits.split(',')[1]))
-
     main(options.outfile is None,
          data,
          plot_titles,
@@ -1189,7 +1197,7 @@ if __name__ == '__main__':
          options.changepoint_means,
          median=options.median,
          tukey=options.tukey,
-         inset_xlimit=inset_xlimits,
+         inset=options.inset,
          one_page=options.one_page,
          legend_off=options.legend_off,
          core_cycles=core_cycles,


### PR DESCRIPTION
Algorithm as follows:
  * Use the first 2.5% of the iterations (50 iterations on a run of 2000)
  * If all changepoints occur in the first 5% of iterations (100 iterations on a run of 2000) then the inset plots up to the last changepoint + 2% of the iterations.
  * Clamp the above to a largest extent of 0->150 iterations.

Test case: [test_insets.pdf](https://github.com/softdevteam/warmup_experiment/files/634409/test_insets.pdf)

Needs squashing.