### PR TITLE
Inset and wallclock times have identical ytick format.

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -671,7 +671,7 @@ def draw_page(is_interactive, executions, cycles_executions,
                 inset.set_ylim([y_min, y_max])  # Same scale as larger subplot.
                 inset.grid(False)
                 inset.set_yticks([y_min, y_min + ((y_max - y_min) / 2.0), y_max])
-                inset.yaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter(YTICK_FORMAT))
+                format_yticks_scientific(inset)
                 inset.xaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
                 inset.yaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
                 # Which iterations go in the inset? By default the first 2.5%.


### PR DESCRIPTION
This PR makes the ytick formats to insets identical to those on the wallclock time axis.

This means that if the yticks are `1.2 x 10^-6` or similar, the inset will be formatted in the same way.

Test case: [test_insets.pdf](https://github.com/softdevteam/warmup_experiment/files/635278/test_insets.pdf)
