### PR TITLE
Add "benchmark" to measure idle core cycles.

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,5 +1,6 @@
 # GNU Make!
-.PHONY: java-benchmarks c-benchmarks clean-java-benchmarks clean-c-benchmarks clean
+.PHONY: java-benchmarks c-benchmarks clean-java-benchmarks \
+	clean-c-benchmarks clean clean-idle
 
 PWD !=		pwd
 
@@ -18,7 +19,7 @@ C_EXTRA_LDFLAGS_binarytrees = -lm
 C_EXTRA_LDFLAGS_nbody = -lm
 C_EXTRA_LDFLAGS_spectralnorm = -lm
 
-all: java-benchmarks c-benchmarks
+all: java-benchmarks c-benchmarks idle/c/bench.so
 
 java-benchmarks:
 	for i in ${BENCHMARKS}; do \
@@ -35,7 +36,7 @@ c-benchmarks:
 		${BENCH_CFLAGS} -o bench.so bench.c || exit $?; \
 		)
 
-clean: clean-c-benchmarks clean-java-benchmarks
+clean: clean-c-benchmarks clean-java-benchmarks clean-idle
 
 clean-java-benchmarks:
 	for i in ${BENCHMARKS}; do \
@@ -46,3 +47,10 @@ clean-c-benchmarks:
 	for i in ${BENCHMARKS}; do \
 		cd ${PWD}/$${i}/c && rm -f bench.so; \
 	done
+
+idle/c/bench.so: idle/c/bench.c
+	cd idle/c && ${CC} ${CFLAGS} ${CPPFLAGS} ${C_EXTRA_LDFLAGS_${i}} \
+		${BENCH_CFLAGS} -o bench.so bench.c || exit $?
+
+clean-idle:
+	-rm -f idle/c/bench.so

--- a/benchmarks/idle/c/bench.c
+++ b/benchmarks/idle/c/bench.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int
+run_iter(int param)
+{
+    sleep(param);
+    return (EXIT_SUCCESS);
+}

--- a/idle.krun
+++ b/idle.krun
@@ -1,0 +1,14 @@
+# Krunified config file aimed to help measure the system idle cycles counts
+
+execfile("warmup.krun", globals()) # inherit settings from the main experiment
+
+VMS = {"C": VMS["C"]}
+VMS["C"]["n_iterations"] = 1
+
+BENCHMARKS = {
+    "idle": 10  # 10 second sleep per exec
+}
+
+# This is just to get a rough idea, so 10 execs is enough.
+# (The benchmark ignores in-process iterations).
+N_EXECUTIONS = 10


### PR DESCRIPTION
(Also use batch mode for ssh -- isolated commit)

We use 10 executions of a 10 seconds sleep (sleep time passed as benchmark parameter).

All of the goodness of the main experiment's pre/post commands are inherited.

This is not designed to be statistically rigorous, as I'm just after a ball-park figure really.

OK?