### PR TITLE
Consistent table entries marked with Pexec counts.

### DIFF
--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -88,9 +88,12 @@ def main(data_dcts, window_size, latex_file, with_preamble=False):
                 else:  # Flat execution, no changepoints.
                     time_to_steadys.append(0.0)
             # Average all information.
-            category, occurences = Counter(categories).most_common()[0]
-            if occurences == n_pexecs:
-                reported_category = STYLE_SYMBOLS[category]
+            if len(set(categories)) == 1 and len(categories) == n_pexecs:
+                reported_category = STYLE_SYMBOLS[categories[0]]
+            elif len(set(categories)) == 1:
+                # Consistent benchmark, but some process execs failed with error.
+                reported_category = ' %s\\scriptsize{($%d$)}' % \
+                                    (STYLE_SYMBOLS[categories[0]], len(categories))
             else:
                 reported_category = STYLE_SYMBOLS['inconsistent']
                 cat_counts = list()

--- a/bin/table_classification_summaries_others
+++ b/bin/table_classification_summaries_others
@@ -76,9 +76,12 @@ def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
                 else:  # Flat execution, no changepoints.
                     time_to_steadys.append(0.0)
             # Average all information.
-            category, occurences = Counter(categories).most_common()[0]
-            if occurences == n_pexecs:
-                reported_category = STYLE_SYMBOLS[category]
+            if len(set(categories)) == 1 and len(categories) == n_pexecs:
+                reported_category = STYLE_SYMBOLS[categories[0]]
+            elif len(set(categories)) == 1:
+                # Consistent benchmark, but some process execs failed with error.
+                reported_category = ' %s\\scriptsize{($%d$)}' % \
+                                    (STYLE_SYMBOLS[categories[0]], len(categories))
             else:
                 reported_category = STYLE_SYMBOLS['inconsistent']
                 cat_counts = list()


### PR DESCRIPTION
This PR makes a small change to the information we place in the tables. Previously we said:

  * For each benchmark:
    * Sort the categories in order of most occurrences 
    * If the most frequently occurring category came us as many times as the total number of process executions (10 in our experiment) print it on its own
    * If not, the benchmark is inconsistent, and a list of categories and their numbers of occurrences should be printed.

This missed an important case --  a consistent benchmark where one or more process execution failed with an error. I don't think we ever saw such a case, but if we had the reader would never have known. Potentially we could have lacked a lot of data and misled the reader into thinking we had no failed benchmarks at all.

This PR changes the tables slightly. Firstly we check whether we have only one category in the process executions (rather than checking the number of process executions). Secondly, we now print the number of process executions next to the sparkline, for consistent benchmarks.

### Bencher 3 table test

![b3table](https://cloud.githubusercontent.com/assets/97674/21423602/cd71d9e2-c835-11e6-86ca-4bfc37bd401b.png)

### DaCapo / Octane table test

![other_tables](https://cloud.githubusercontent.com/assets/97674/21423607/d345c6ee-c835-11e6-84d8-f4590ed549b9.png)
