### PR TITLE
Annotate segment means

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -425,7 +425,7 @@ class ProcessExecChart(object):
         self.minor_xticks = compute_grid_offsets(self.x_bounds[0], self.x_bounds[1], GRID_MINOR_X_DIVS)
         # Shared information for segment annotations.
         self.annotations_x_padding = (x_bounds[1] - x_bounds[0]) * 0.01
-        self.annotations_y_padding = (y_range[1] - y_range[0]) * 0.02
+        self.annotations_y_padding = (y_range[1] - y_range[0]) * 0.1
         # Calculate the number of plots needed.
         self.n_rows = 1
         if cycles_data:
@@ -581,7 +581,9 @@ class ProcessExecChart(object):
                               zorder=ZORDER_CHANGEPOINTS)
 
     def _plot_segment_annotations(self, axis):
-        """Annotate axis with segment means as text."""
+        """Annotate axis with segment means as text.
+        TODO: Check the user has passed in --with-changepoint-means!
+        """
         if self.changepoints:
             for cpt in xrange(len(self.changepoint_means)):
                 if cpt == 0:
@@ -599,7 +601,7 @@ class ProcessExecChart(object):
                 y_coord = max(y_slice) + self.annotations_y_padding
                 axis.text(x_coord, y_coord, '%.4f' % self.changepoint_means[cpt],
                           horizontalalignment='left', verticalalignment='center',
-                          fontsize=INSET_TICK_FONTSIZE)
+                          fontsize=INSET_TICK_FONTSIZE, rotation=90)
 
     def plot_cycles_data(self):
         """Add core cycles data on another set of charts."""

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -423,25 +423,23 @@ def draw_process_exec(grid_cell, data, cycles_data,
                                zorder=ZORDER_CHANGEPOINTS,
                                linewidths=[LINE_WIDTH for _ in xrange(len(means))])
         axis1.add_collection(lines)
-        # If the classification is not 'flat' or 'no steady state', see if there
-        # are any 'interesting' segments to annotate with segment means.
-        if ((classification == 'warmup' or classification == 'slowdown')
-                and len(changepoints) > 1):
-            y_padding = (y_range[1] - y_range[0]) / 10.0
-            # Annotate penultimate segment mean.
-            if changepoints[-1] < 100:
-                x_coord = 0
-            else:
-                x_coord = changepoints[-1] - 100
-            y_coord = max(data_narray[x_coord:changepoints[-1] + 250]) + y_padding
-            axis1.text(x_coord, y_coord, '%.4f' % changepoint_means[-2],
-                    horizontalalignment='left', verticalalignment='center',
-                    fontsize=INSET_TICK_FONTSIZE)
-            # Annotate last segment mean.
-            x_coord = changepoints[-1] + 20  # Same y_coord for each annotation.
-            axis1.text(x_coord, y_coord, '%.4f' % changepoint_means[-1],
-                    horizontalalignment='left', verticalalignment='center',
-                    fontsize=INSET_TICK_FONTSIZE)
+        # If the classification is not 'flat', see if there are any
+        # 'interesting' segments to annotate with segment means.
+        if classification != 'flat':
+            y_padding = (y_range[1] - y_range[0]) * 0.01
+            for cpt in xrange(len(changepoint_means)):
+                if cpt == 0:
+                    x_coord = 0
+                    y_coord = max(data_narray[0:changepoints[0]]) + y_padding
+                elif cpt == len(changepoint_means) - 1:
+                    x_coord = changepoints[-1] + 20
+                    y_coord = max(data_narray[changepoints[-1]:-1]) + y_padding
+                else:
+                    x_coord = changepoints[cpt - 1] + 20
+                    y_coord = max(data_narray[changepoints[cpt - 1]:changepoints[cpt]]) + y_padding
+                axis1.text(x_coord, y_coord, '%.4f' % changepoint_means[cpt],
+                        horizontalalignment='left', verticalalignment='center',
+                        fontsize=INSET_TICK_FONTSIZE)
 
     # Draw changepoints as blobs, without changepoint means.
     if changepoints and not changepoint_means:

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -171,6 +171,7 @@ def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
     instr_pages = list()
     all_outliers, all_common, all_unique = list(), list(), list()
     all_changepoints, all_changepoint_means = list(), list()
+    all_classifications = list()
 
     # By default, each benchmark from each machine is placed on a separate
     # page. If the --one-page switch has been passed in, then we place
@@ -182,6 +183,7 @@ def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
         instr_page = list()
         page_common, page_unique, page_outlier = list(), list(), list()
         page_changepoints, page_changepoint_means = list(), list()
+        page_classifications = list()
         for key in sorted(data_dcts['data']):
             for machine in sorted(data_dcts['data'][key]):
                 for index, run_seq in enumerate(data_dcts['data'][key][machine]):
@@ -208,12 +210,15 @@ def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
                     if changepoints:
                         page_changepoints.append(data_dcts['changepoints'][key][machine][index])
                         page_changepoint_means.append(None)
+                        page_classifications.append(data_dcts['classifications'][key][machine][index])
                     if changepoint_means:
                         page_changepoints.append(data_dcts['changepoints'][key][machine][index])
                         page_changepoint_means.append(data_dcts['changepoint_means'][key][machine][index])
+                        page_classifications.append(data_dcts['classifications'][key][machine][index])
                     else:
                         page_changepoints.append(None)
                         page_changepoint_means.append(None)
+                        page_classifications.append(None)
         pages.append(page)
         cycles_pages.append(cycles_page)
         instr_pages.append(instr_page)
@@ -223,6 +228,7 @@ def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
         all_unique.append(page_unique)
         all_changepoints.append(page_changepoints)
         all_changepoint_means.append(page_changepoint_means)
+        all_classifications.append(page_classifications)
     else:  # Create multiple pages.
         for key in sorted(data_dcts['data']):
             for machine in sorted(data_dcts['data'][key]):
@@ -243,12 +249,15 @@ def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
                 if changepoints:
                     all_changepoints.append(data_dcts['changepoints'][key][machine])
                     all_changepoint_means.append(None)
+                    all_classifications.append(data_dcts['classifications'][key][machine])
                 elif changepoint_means:
                     all_changepoints.append(data_dcts['changepoints'][key][machine])
                     all_changepoint_means.append(data_dcts['changepoint_means'][key][machine])
+                    all_classifications.append(data_dcts['classifications'][key][machine])
                 else:
                     all_changepoints.append(None)
                     all_changepoint_means.append(None)
+                    all_classifications.append(None)
 
     # Draw each page and display (interactive mode) or save to disk.
     try:
@@ -280,14 +289,15 @@ def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
             unique = only_uncrashed(all_unique[index])
             changepoints = only_uncrashed(all_changepoints[index])
             changepoint_means = only_uncrashed(all_changepoint_means[index])
+            classifications = only_uncrashed(all_classifications[index])
 
             fig = draw_page(is_interactive, wct_page, cycles_page,
                                          instr_page, subplot_titles,
                                          window_size, xlimits, outliers,
                                          unique, common, changepoints,
-                                         changepoint_means, median, tukey,
-                                         inset, legend_off, core_cycles,
-                                         cycles_ylimits)
+                                         changepoint_means, classifications,
+                                         median, tukey, inset, legend_off,
+                                         core_cycles, cycles_ylimits)
             if fig is not None:
                 if not is_interactive:
                     pdf.savefig(fig, dpi=fig.dpi, orientation='landscape',
@@ -315,7 +325,7 @@ def _get_scatter_points_within_bounds(scatter, x_bounds):
 def draw_process_exec(grid_cell, data, cycles_data,
                  instr_data, instr_y_ranges, title, x_bounds, y_range, window_size,
                  outliers, unique, common, changepoints, changepoint_means,
-                 median, tukey, core_cycles, cycles_ylimits):
+                 classification, median, tukey, core_cycles, cycles_ylimits):
     iterations = numpy.array(xrange(x_bounds[0], x_bounds[1]))
     # Marshal data into numpy arrays.
     data_narray = numpy.array(data[x_bounds[0]:x_bounds[1]])
@@ -538,8 +548,8 @@ def draw_process_exec(grid_cell, data, cycles_data,
 
 def draw_page(is_interactive, executions, cycles_executions,
               instr_executions, titles, window_size, xlimits,
-              outliers, unique, common, changepoints, changepoint_means, median,
-              tukey, inset=False, legend_off=True, core_cycles=(0,1,2,3),
+              outliers, unique, common, changepoints, changepoint_means, classifications,
+              median, tukey, inset=False, legend_off=True, core_cycles=(0,1,2,3),
               cycles_ylimits=None):
     """Plot a page of benchmarks.
     """
@@ -610,6 +620,7 @@ def draw_page(is_interactive, executions, cycles_executions,
     cycles_data, instr_data = None, None
     outliers_exec, unique_exec, common_exec = None, None, None
     changepoint_exec, changepoint_mean_exec = None, None
+    classification_exec = None
     while index < n_execs:
         data = executions[index]
         if cycles_executions:
@@ -624,8 +635,10 @@ def draw_page(is_interactive, executions, cycles_executions,
             common_exec = common[index]
         if changepoints:
             changepoint_exec = changepoints[index]
+            classification_exec = classifications[index]
         if changepoint_means:
             changepoint_mean_exec = changepoint_means[index]
+            classification_exec = classifications[index]
         # Get axis and draw plot.
         inner_grid = outer_grid[row, col]
         x_bounds = [xlimits_start, xlimits_stop]
@@ -633,8 +646,8 @@ def draw_page(is_interactive, executions, cycles_executions,
                               instr_data, instr_y_ranges,
                               titles[index], x_bounds, [y_min, y_max], window_size,
                               outliers_exec, unique_exec, common_exec, changepoint_exec,
-                              changepoint_mean_exec, median, tukey, core_cycles,
-                              cycles_ylimits)
+                              changepoint_mean_exec, classification_exec,
+                              median, tukey, core_cycles, cycles_ylimits)
         wallclock_axes.append(wc_axis)
         col += 1
         if col == MAX_SUBPLOTS_PER_ROW:
@@ -783,8 +796,8 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
     data_dictionary = {'data': dict(),  'cycles_counts': dict(),
                        'instr_data': dict(),  # Per-VM information.
                        'changepoints': dict(), 'changepoint_means': dict(),
-                       'all_outliers': dict(), 'common_outliers': dict(),
-                       'unique_outliers': dict(),
+                       'classifications': dict(), 'all_outliers': dict(),
+                       'common_outliers': dict(), 'unique_outliers': dict(),
                       }
 
     plot_titles = dict()  # All subplot titles.
@@ -868,6 +881,7 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                         data_dictionary['instr_data'][key] = dict()
                         data_dictionary['changepoints'][key] = dict()
                         data_dictionary['changepoint_means'][key] = dict()
+                        data_dictionary['classifications'][key] = dict()
                         data_dictionary['all_outliers'][key] = dict()
                         data_dictionary['common_outliers'][key] = dict()
                         data_dictionary['unique_outliers'][key] = dict()
@@ -889,9 +903,11 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                     if changepoints:
                         data_dictionary['changepoints'][key][machine] = data['changepoints'][key]
                         data_dictionary['changepoint_means'][key][machine] = data['changepoint_means'][key]
+                        data_dictionary['classifications'][key][machine] = data['classifications'][key]
                     else:
                         data_dictionary['changepoints'][key][machine] = None
                         data_dictionary['changepoint_means'][key][machine] = None
+                        data_dictionary['classifications'][key][machine] = None
                     if outliers or unique_outliers:
                         data_dictionary['all_outliers'][key][machine] = data['all_outliers'][key]
                         data_dictionary['common_outliers'][key][machine] = data['common_outliers'][key]
@@ -961,9 +977,11 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                     if changepoints:
                         data_dictionary['changepoints'][key][machine] = list()
                         data_dictionary['changepoint_means'][key][machine] = list()
+                        data_dictionary['classifications'][key][machine] = list()
                     else:
                         data_dictionary['changepoints'][key][machine] = None
                         data_dictionary['changepoint_means'][key][machine] = None
+                        data_dictionary['classifications'][key][machine] = None
                     if outliers or unique_outliers:
                         data_dictionary['all_outliers'][key][machine] = list()
                         data_dictionary['common_outliers'][key][machine] = list()
@@ -1006,6 +1024,7 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                             if changepoints:
                                 data_dictionary['changepoints'][key][machine].append(data['changepoints'][key][p_exec])
                                 data_dictionary['changepoint_means'][key][machine].append(data['changepoint_means'][key][p_exec])
+                                data_dictionary['classifications'][key][machine].append(data['classifications'][key][p_exec])
                             if outliers or unique_outliers:
                                 data_dictionary['all_outliers'][key][machine].append(data['all_outliers'][key][p_exec])
                                 data_dictionary['common_outliers'][key][machine].append(data['common_outliers'][key][p_exec])

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -423,6 +423,26 @@ def draw_process_exec(grid_cell, data, cycles_data,
                                zorder=ZORDER_CHANGEPOINTS,
                                linewidths=[LINE_WIDTH for _ in xrange(len(means))])
         axis1.add_collection(lines)
+        # If the classification is not 'flat' or 'no steady state', see if there
+        # are any 'interesting' segments to annotate with segment means.
+        if ((classification == 'warmup' or classification == 'slowdown')
+                and len(changepoints) > 1):
+            y_padding = (y_range[1] - y_range[0]) / 10.0
+            # Annotate penultimate segment mean.
+            if changepoints[-1] < 100:
+                x_coord = 0
+            else:
+                x_coord = changepoints[-1] - 100
+            y_coord = max(data_narray[x_coord:changepoints[-1] + 250]) + y_padding
+            axis1.text(x_coord, y_coord, '%.4f' % changepoint_means[-2],
+                    horizontalalignment='left', verticalalignment='center',
+                    fontsize=INSET_TICK_FONTSIZE)
+            # Annotate last segment mean.
+            x_coord = changepoints[-1] + 20  # Same y_coord for each annotation.
+            axis1.text(x_coord, y_coord, '%.4f' % changepoint_means[-1],
+                    horizontalalignment='left', verticalalignment='center',
+                    fontsize=INSET_TICK_FONTSIZE)
+
     # Draw changepoints as blobs, without changepoint means.
     if changepoints and not changepoint_means:
         if x_bounds[0] > 0:

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -423,20 +423,19 @@ def draw_process_exec(grid_cell, data, cycles_data,
                                zorder=ZORDER_CHANGEPOINTS,
                                linewidths=[LINE_WIDTH for _ in xrange(len(means))])
         axis1.add_collection(lines)
-        # If the classification is not 'flat', see if there are any
-        # 'interesting' segments to annotate with segment means.
-        if classification != 'flat':
+        # If the classification is not 'flat', annotate segments with their means.
+        if classification != 'flat' and changepoints:
             y_padding = (y_range[1] - y_range[0]) * 0.01
             for cpt in xrange(len(changepoint_means)):
                 if cpt == 0:
-                    x_coord = 0
-                    y_coord = max(data_narray[0:changepoints[0]]) + y_padding
+                    x_coord = x_bounds[0]
+                    y_coord = max(data[x_bounds[0]:changepoints[0]]) + y_padding
                 elif cpt == len(changepoint_means) - 1:
                     x_coord = changepoints[-1] + 20
-                    y_coord = max(data_narray[changepoints[-1]:-1]) + y_padding
+                    y_coord = max(data[changepoints[-1]:]) + y_padding
                 else:
                     x_coord = changepoints[cpt - 1] + 20
-                    y_coord = max(data_narray[changepoints[cpt - 1]:changepoints[cpt]]) + y_padding
+                    y_coord = max(data[changepoints[cpt - 1]:changepoints[cpt]]) + y_padding
                 axis1.text(x_coord, y_coord, '%.4f' % changepoint_means[cpt],
                         horizontalalignment='left', verticalalignment='center',
                         fontsize=INSET_TICK_FONTSIZE)

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -429,7 +429,7 @@ def draw_process_exec(grid_cell, data, cycles_data,
             for cpt in xrange(len(changepoint_means)):
                 if cpt == 0:
                     x_coord = x_bounds[0]
-                    if changepoints[0] > 0:
+                    if len(data[x_bounds[0]:changepoints[0]]) > 0:
                         y_coord = max(data[x_bounds[0]:changepoints[0]]) + y_padding
                     else:
                         y_coord = data[x_bounds[0]] + y_padding

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -429,7 +429,10 @@ def draw_process_exec(grid_cell, data, cycles_data,
             for cpt in xrange(len(changepoint_means)):
                 if cpt == 0:
                     x_coord = x_bounds[0]
-                    y_coord = max(data[x_bounds[0]:changepoints[0]]) + y_padding
+                    if changepoints[0] > 0:
+                        y_coord = max(data[x_bounds[0]:changepoints[0]]) + y_padding
+                    else:
+                        y_coord = data[x_bounds[0]] + y_padding
                 elif cpt == len(changepoint_means) - 1:
                     x_coord = changepoints[-1] + 20
                     y_coord = max(data[changepoints[-1]:]) + y_padding

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -671,7 +671,7 @@ def draw_page(is_interactive, executions, cycles_executions,
             if best_rect:
                 # Create and style the inset.
                 inset = add_inset_to_axis(fig, axis, best_rect)
-                inset.set_ylim([y_min, y_max])  # Same scale as larger subplot.
+                inset.set_ylim(axis.get_ylim())
                 inset.grid(False)
                 inset.set_yticks([y_min, y_min + ((y_max - y_min) / 2.0), y_max])
                 format_yticks_scientific(inset)

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -423,6 +423,9 @@ class ProcessExecChart(object):
         # Shared information for grid styles.
         self.major_xticks = compute_grid_offsets(self.x_bounds[0], self.x_bounds[1], GRID_MAJOR_X_DIVS)
         self.minor_xticks = compute_grid_offsets(self.x_bounds[0], self.x_bounds[1], GRID_MINOR_X_DIVS)
+        # Shared information for segment annotations.
+        self.annotations_x_padding = (x_bounds[1] - x_bounds[0]) * 0.01
+        self.annotations_y_padding = (y_range[1] - y_range[0]) * 0.02
         # Calculate the number of plots needed.
         self.n_rows = 1
         if cycles_data:
@@ -500,7 +503,7 @@ class ProcessExecChart(object):
                         color=LINE_COLOUR, zorder=ZORDER_DATA, linewidth=PLOT_LINE_WIDTH)
         self.wallclock_axis.autoscale(enable=False, axis='both')
         self._plot_changepoints(self.wallclock_axis, large_markers=True)
-        self._plot_segment_annotations(self.wallclock_axis, self.y_range)
+        self._plot_segment_annotations(self.wallclock_axis)
         self._plot_outliers(self.wallclock_axis, large_markers=True)
         if self.median:  # Plot the median.
             self.plot_median(self.wallclock_axis)
@@ -577,25 +580,23 @@ class ProcessExecChart(object):
                               c=LINE_COLOUR, marker=OUTLIER_MARKER, s=size,
                               zorder=ZORDER_CHANGEPOINTS)
 
-    def _plot_segment_annotations(self, axis, y_range):
-        # If the classification is not 'flat', annotate segments with their means.
-        if self.classification != 'flat' and self.changepoints:
-            y_padding = (y_range[1] - y_range[0]) * 0.01
+    def _plot_segment_annotations(self, axis):
+        """Annotate axis with segment means as text."""
+        if self.changepoints:
             for cpt in xrange(len(self.changepoint_means)):
                 if cpt == 0:
                     x_coord = self.x_bounds[0]
                     if len(self.wallclock_data[self.x_bounds[0]:self.changepoints[0]]) > 0:
-                        y_coord = (max(self.wallclock_data[self.x_bounds[0]:self.changepoints[0]])
-                                   + y_padding)
+                        y_slice = self.wallclock_data[self.x_bounds[0]:self.changepoints[0]]
                     else:
-                        y_coord = self.wallclock_data[self.x_bounds[0]] + y_padding
+                        y_slice = self.wallclock_data[self.x_bounds[0]]
                 elif cpt == len(self.changepoint_means) - 1:
-                    x_coord = self.changepoints[-1] + 20
-                    y_coord = max(self.wallclock_data[self.changepoints[-1]:]) + y_padding
+                    x_coord = self.changepoints[-1] + self.annotations_x_padding
+                    y_slice = self.wallclock_data[self.changepoints[-1] + 1:]
                 else:
-                    x_coord = self.changepoints[cpt - 1] + 20
-                    y_coord = (max(self.wallclock_data[self.changepoints[cpt - 1]:self.changepoints[cpt]])
-                               + y_padding)
+                    x_coord = self.changepoints[cpt - 1] + self.annotations_x_padding
+                    y_slice = self.wallclock_data[self.changepoints[cpt - 1] + 1:self.changepoints[cpt]]
+                y_coord = max(y_slice) + self.annotations_y_padding
                 axis.text(x_coord, y_coord, '%.4f' % self.changepoint_means[cpt],
                           horizontalalignment='left', verticalalignment='center',
                           fontsize=INSET_TICK_FONTSIZE)


### PR DESCRIPTION
This is a simple first step towards resolving #288 

Whenever a warmup or slowdown process execution has > 1 changepoint, the last and penultimate segments are annotated with their means, drawn either side of the last changepoint. 

### Small test case

[issue_288_test.pdf](https://github.com/softdevteam/warmup_experiment/files/685946/issue_288_test.pdf)

### Larger test case (v0.7)

[issue_288_test_large.pdf](https://github.com/softdevteam/warmup_experiment/files/685947/issue_288_test_large.pdf)
