### PR TITLE
Fix xlimits

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -383,6 +383,11 @@ def draw_process_exec(grid_cell, data, cycles_data,
     # Draw change points and means between them, optionally.
     if changepoint_means:
         means = list()  # Draw means between ((x0, y0), (x1, y1)) pairs.
+        if x_bounds[0] > 0:
+            for index, changepoint in enumerate(changepoints):
+                if changepoint < x_bounds[0]:
+                    del changepoint_means[index]
+                    del changepoints[index]
         assert len(changepoints) == len(changepoint_means) - 1
         for index, x_location in enumerate(changepoints):
             # Draw changepoint.
@@ -390,18 +395,18 @@ def draw_process_exec(grid_cell, data, cycles_data,
                          zorder=ZORDER_CHANGEPOINTS, color=CHANGEPOINT_LINE_COLOR,
                          linewidth=LINE_WIDTH)
             if index == 0:
-                means.append([(0, changepoint_means[0]),
+                means.append([(x_bounds[0], changepoint_means[0]),
                              (x_location, changepoint_means[0])])
             else:
                 means.append([(changepoints[index - 1], changepoint_means[index]),
                              (x_location, changepoint_means[index])])
         if len(changepoints) == 0:
             # No changepoints in this execution, but we want to draw the mean.
-            means.append([(0, changepoint_means[-1]),
-                         (len(data_narray), changepoint_means[-1])])
+            means.append([(x_bounds[0], changepoint_means[-1]),
+                         (x_bounds[1], changepoint_means[-1])])
         else:
             means.append([(changepoints[-1], changepoint_means[-1]),
-                         (len(data_narray), changepoint_means[-1])])
+                         (x_bounds[1], changepoint_means[-1])])
         # Add changepoint means to chart, on top of all other splines.
         assert len(means) == len(changepoint_means)
         lines = LineCollection(means, color=CHANGEPOINT_LINE_COLOR,
@@ -410,6 +415,10 @@ def draw_process_exec(grid_cell, data, cycles_data,
         axis1.add_collection(lines)
     # Draw changepoints as blobs, without changepoint means.
     if changepoints and not changepoint_means:
+        if x_bounds[0] > 0:
+            for index, changepoint in enumerate(changepoints):
+                if changepoint < x_bounds[0]:
+                    del changepoints[index]
         axis1.scatter(changepoints, [y_range[0] for _ in changepoints],
                       c=LINE_COLOUR, marker=OUTLIER_MARKER, s=OUTLIER_SIZE,
                       zorder=ZORDER_CHANGEPOINTS)

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -418,7 +418,7 @@ def draw_process_exec(grid_cell, data, cycles_data,
         medians = list()
         pc_bands = (list(), list())
         for index, datum in enumerate(data[x_bounds[0]:x_bounds[1]]):
-            window = get_window(index, window_size, data[x_bounds[0]:x_bounds[1]])
+            window = get_window(index + x_bounds[0], window_size, data)
             if not window:
                 medians.append(numpy.nan)
             else:

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -663,7 +663,7 @@ def draw_page(is_interactive, executions, cycles_executions,
                 rect = (1.0 - INSET_DEFAULT_WIDTH - left_offset - INSET_PADDING,
                         bottom, INSET_DEFAULT_WIDTH, INSET_DEFAULT_HEIGHT)
                 inset_collides, dist = collide_rect(rect, fig, axis,
-                                     executions[index][x_bounds[0]:x_bounds[1]])
+                                     executions[index], x_bounds)
                 if not inset_collides:
                     if not best_rect or round(dist - best_distance) >= INSET_DIST_DELTA:
                         best_distance = dist
@@ -679,11 +679,12 @@ def draw_page(is_interactive, executions, cycles_executions,
                 inset.yaxis.set_tick_params(labelsize=INSET_TICK_FONTSIZE)
                 # Which iterations go in the inset? By default the first 2.5%.
                 one_pc = len(executions[index][x_bounds[0]:x_bounds[1]]) / 100.0  # 1% of the iterations.
-                inset_xlimit = (0, int(one_pc * 2.5))
+                inset_xlimit = (x_bounds[0], x_bounds[0] + int(one_pc * 2.5))
                 # If all the changepoints occur at the start of the process exec,
                 # include them all and a few extra executions.
                 if changepoints and changepoints[index]:
-                    if changepoints[index][x_bounds[0]:x_bounds[1]][-1] <= int(one_pc * 5.0):
+                    if (changepoints[index][x_bounds[0]:x_bounds[1]] and
+                          changepoints[index][x_bounds[0]:x_bounds[1]][-1] <= int(one_pc * 5.0)):
                         inset_xlimit = (0, (changepoints[index][x_bounds[0]:x_bounds[1]][-1]
                                             + int(one_pc * 2.0)))
                 # Clamp the extent of the inset.

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -552,6 +552,9 @@ def draw_page(is_interactive, executions, cycles_executions,
     else:
         try:
             xlimits_start, xlimits_stop = [int(x) for x in xlimits.split(',')]
+            if xlimits_start < 0 or xlimits_stop > len(executions[0]):
+                fatal_error('You specified %s as xlimits, but your data contains'
+                            ' iterations between 0 and %d' % (xlimits, len(executions[0])))
         except ValueError:
             fatal_error('Invalid xlimits pair: %s' % xlimits)
 


### PR DESCRIPTION
This PR fixes a number of bugs related to `--xlimits`. Each Issue has been resolved in a single commit.

The following lists the relevant Issues and test cases:

### CLI values were not previously checked for validity

Fixes #235 

### Median and Tukey band

`-m` and `-t` are used to draw the median and Tukey interval, which are used to determine which data are outliers. To avoid labelling the slow iterations at the start of a warmup benchmark outliers, we do not consider any data until we have a full "window" of data. For example, if the window size is 200, then the first 100 iterations are ignored. Iteration 101 is then has 100 data preceding it (and 100 after), to make a full window, therefore iteration 101 might be an outlier. Previously, if we set `--xlimits` to start charting after the window size, we (incorrectly) did not draw the median or Tukey interval for iterations 300-400.

  * **Before commit:** [before_xlimit_fix_tukey.pdf](https://github.com/softdevteam/warmup_experiment/files/704965/before_xlimit_fix_tukey.pdf)
  * **After commit (`-x 300,500`):** [after_xlimit_fix_tukey_1.pdf](https://github.com/softdevteam/warmup_experiment/files/704967/after_xlimit_fix_tukey_1.pdf)
   * **After commit (`-x 100,500`):** [after_xlimit_fix_tukey_2.pdf](https://github.com/softdevteam/warmup_experiment/files/704969/after_xlimit_fix_tukey_2.pdf)
  * **After commit (`-x 50,500`):** [after_xlimit_fix_tukey_3.pdf](https://github.com/softdevteam/warmup_experiment/files/704972/after_xlimit_fix_tukey_3.pdf)

Fixes #173 

### Changepoints and changepoint means

Previously changepoints and changepoint means were not clamped to the x bounds that the user specified.

  * **Before commit (changepoints):** [before_xlimit_changepoint_fix_1.pdf](https://github.com/softdevteam/warmup_experiment/files/704979/before_xlimit_changepoint_fix_1.pdf)
  * **Before commit (changepoint means):** [before_xlimit_changepoint_fix_2.pdf](https://github.com/softdevteam/warmup_experiment/files/704983/before_xlimit_changepoint_fix_2.pdf)
  * **After commit (changepoints, `-x 100,500`):** [after_xlimit_changepoint_fix_1.pdf](https://github.com/softdevteam/warmup_experiment/files/704988/after_xlimit_changepoint_fix_1.pdf)
  * **After commit (changepoints, no xlimits):** [after_xlimit_changepoint_fix_2.pdf](https://github.com/softdevteam/warmup_experiment/files/704990/after_xlimit_changepoint_fix_2.pdf)
  * **After commit (changepoint means, `-x 100,500`):** [after_xlimit_changepoint_fix_3.pdf](https://github.com/softdevteam/warmup_experiment/files/704991/after_xlimit_changepoint_fix_3.pdf)
  * **After commit (changepoint means, no xlimits):** [after_xlimit_changepoint_fix_4.pdf](https://github.com/softdevteam/warmup_experiment/files/704992/after_xlimit_changepoint_fix_4.pdf)

Fixes #298 

### Inset placement

Insets were previously placed over data when `--xlimits` was used.

  * **Before commit:** [before_xlimit_inset_fix.pdf](https://github.com/softdevteam/warmup_experiment/files/704994/before_xlimit_inset_fix.pdf)
  * **After commit (`-x 100,500`):** [after_xlimit_inset_fix_1.pdf](https://github.com/softdevteam/warmup_experiment/files/705000/after_xlimit_inset_fix_1.pdf)
  * **After commit (no xlimits):** [after_xlimit_inset_fix_2.pdf](https://github.com/softdevteam/warmup_experiment/files/705001/after_xlimit_inset_fix_2.pdf)

Fixes #268 