### PR TITLE
Dacapo better timer

### DIFF
--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -17,9 +17,9 @@ WORKING_BENCHS = ['avrora', 'fop', 'h2', 'jython', 'luindex', 'lusearch',
 
 JAR = os.path.join(os.path.dirname(__file__), "dacapo-9.12-bach.jar")
 
-JVMCI_JAVA_HOME = find_internal_jvmci_java_home('%s/work/jvmci/' % WARMUP_DIR)
+JVMCI_JAVA_HOME = find_internal_jvmci_java_home('%s/work/graal-jvmci-8/' % WARMUP_DIR)
 JAVA_VMS = {
-    "graal" : "%s/work/mx/mx --java-home=%s -p %s/work/graal/ -Mjit vm" % (WARMUP_DIR, JVMCI_JAVA_HOME, WARMUP_DIR),
+    "graal" : "%s/work/mx/mx --java-home=%s -p %s/work/graal/ vm -XX:+UseJVMCICompiler" % (WARMUP_DIR, JVMCI_JAVA_HOME, WARMUP_DIR),
     "hotspot" : "$JAVA_HOME/bin/java"
 }
 

--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -54,8 +54,8 @@ def main():
                         assert benchmark in line
                         line = line.split()
                         index = line.index("in")
-                        assert line[index + 2] == "msec"
-                        output.append(str(Decimal(line[index + 1]) / 1000))
+                        assert line[index + 2] == "nsec"
+                        output.append(str(Decimal(line[index + 1]) / 1000000000))
                     assert len(output) == ITERATIONS
                     writer.writerow([process, benchmark] + output)
                 sys.stdout.write("\n")

--- a/patches/dacapo.diff
+++ b/patches/dacapo.diff
@@ -1,0 +1,29 @@
+--- Callback_old.java	Mon Jan 16 16:54:31 2017
++++ Callback.java	Mon Jan 16 16:54:52 2017
+@@ -168,7 +168,7 @@
+   };
+ 
+   protected void start(String benchmark, boolean warmup) {
+-    timer = System.currentTimeMillis();
++    timer = System.nanoTime();
+     System.err.print("===== DaCapo " + TestHarness.getBuildVersion() + " " + benchmark + " starting ");
+     System.err.println((warmup ? ("warmup " + (iterations + 1) + " ") : "") + "=====");
+     System.err.flush();
+@@ -185,7 +185,7 @@
+   }
+ 
+   public void stop(boolean warmup) {
+-    elapsed = System.currentTimeMillis() - timer;
++    elapsed = System.nanoTime() - timer;
+   }
+ 
+   /* Announce completion of the benchmark (pass or fail) */
+@@ -202,7 +202,7 @@
+     System.err.print("===== DaCapo " + TestHarness.getBuildVersion() + " " + benchmark);
+     if (valid) {
+       System.err.print(warmup ? (" completed warmup " + (iterations + 1) + " ") : " PASSED ");
+-      System.err.print("in " + elapsed + " msec ");
++      System.err.print("in " + elapsed + " nsec ");
+     } else {
+       System.err.print(" FAILED " + (warmup ? "warmup " : ""));
+     }


### PR DESCRIPTION
This commit a) changes DaCapo to use a better-than-millisecond timer b) unbreaks Graal when running DaCapo.

Here's a (very small) subset of the output, so that we can see that it's working:

```
0,avrora,3.00826257,1.750913261,1.667840536,1.589991021,1.587320767,1.584059504,
1.569380714,1.565149822,1.559371238,1.582767391,1.580639695,1.583717649,1.572852
318,1.576273995,1.585546299,1.556570193,1.583217447,1.562401111,1.584982765,1.58
9988128,1.566040396,1.600723317,1.560411806,1.571652799,1.582280081,1.564775326,1.566714208,1.570006142,1.578958131,1.573332607
```