### PR TITLE
Improve y-tick labels

### DIFF
--- a/warmup/plotting.py
+++ b/warmup/plotting.py
@@ -1,7 +1,7 @@
 import math
 
 from matplotlib import pyplot
-from matplotlib.ticker import ScalarFormatter
+from matplotlib.ticker import ScalarFormatter, FormatStrFormatter
 
 SPINE_LINESTYLE = 'solid'
 SPINE_LINEWIDTH = 1
@@ -83,17 +83,21 @@ def format_yticks_scientific(axis):
     multiplies each ticklabel). Remove the multiplier from the top-left hand
     corner of the plot, and add it to the ticklabel instead.
     """
-    formatter = ScalarFormatter(useMathText=True)
-    formatter.set_scientific(True)
-    formatter.set_powerlimits((-2, 2))
-    axis.yaxis.set_major_formatter(formatter)
-    y_axis = axis.yaxis
+    y_min, y_max= axis.get_ylim()
+    if y_max > 100000 or (y_min < 0.00001 and y_min > 0.0):
+        formatter = ScalarFormatter(useMathText=True, useOffset=False)
+        formatter.set_scientific(True)
+        formatter.set_powerlimits((-6, 6))
+        axis.yaxis.set_major_formatter(formatter)
+    else:
+        formatter = FormatStrFormatter('%.5f')
+        axis.yaxis.set_major_formatter(formatter)
     pyplot.draw()
-    offset = y_axis.get_offset_text().get_text()
+    offset = axis.yaxis.get_offset_text().get_text()
     if len(offset) > 0:
         labels = [label.get_text() + offset for label in axis.get_yticklabels()]
         axis.set_yticklabels(labels)
-        y_axis.offsetText.set_visible(False)
+        axis.yaxis.offsetText.set_visible(False)
 
 
 def get_unified_yrange(executions, xlimits_start, xlimits_stop, padding=0.02):


### PR DESCRIPTION
Fixes #306 

### Before / after tests

See page 3:

  * Before: [test_ticks_before.pdf](https://github.com/softdevteam/warmup_experiment/files/714572/test_ticks_before.pdf)
  * After: [test_ticks.pdf](https://github.com/softdevteam/warmup_experiment/files/714573/test_ticks.pdf)

See page 52:

  * Before: [bencher3_test_ticks_before.pdf](https://github.com/softdevteam/warmup_experiment/files/714605/bencher3_test_ticks_before.pdf)
  * After: [bencher3_test_ticks_after.pdf](https://github.com/softdevteam/warmup_experiment/files/714735/bencher3_test_ticks_after.pdf)


### Other test cases

  * Da capo: [test_ticks_dacapo.pdf](https://github.com/softdevteam/warmup_experiment/files/714571/test_ticks_dacapo.pdf)
