### PR TITLE
Pass LD_LIBRARY_FLAGS to octane. Skip spidermonkey on OpenBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ ifeq (${UNAME}, OpenBSD)
 	JAVA_INC = ${JAVA_HOME}/include/openbsd
 	GCC_LIB_DIR = ${PWD}/work/gcc-inst/lib
 endif
+LIBKRUN_DIR=${PWD}/krun/libkrun
 
 CC=${PWD}/work/gcc-inst/bin/zgcc
 
@@ -73,7 +74,7 @@ bench-dacapo: build-krun build-vms
 	bin/csv_to_krun_json -u "`uname -a`" -v HotSpot -l Java dacapo.hotspot.results
 
 bench-octane: build-krun build-vms
-	PYTHONPATH=krun/ ${PYTHON} extbench/runoctane.py
+	PYTHONPATH=krun/ LD_LIBRARY_PATH=${GCC_LIB_DIR}:${LIBKRUN_DIR} ${PYTHON} extbench/runoctane.py
 	bin/csv_to_krun_json -u "`uname -a`" -v V8 -l JavaScript octane.v8.results
 	bin/csv_to_krun_json -u "`uname -a`" -v SpiderMonkey -l JavaScript octane.spidermonkey.results
 

--- a/extbench/runoctane.py
+++ b/extbench/runoctane.py
@@ -6,13 +6,18 @@ from krun.platform import detect_platform
 from krun.util import run_shell_cmd_bench
 
 WARMUP_DIR = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
+LD_LIBRARY_PATH=os.environ.get("LD_LIBRARY_PATH", "")
 
 JAVASCRIPT_VMS = {
-    "v8": "sh -c 'cd %s/extbench/octane && LD_LIBRARY_PATH=%s/krun/libkrun %s/work/v8/out/native/d8 run_we.js'"
-          % (WARMUP_DIR, WARMUP_DIR, WARMUP_DIR),
-    "spidermonkey": "sh -c 'cd %s/extbench/octane && %s/work/spidermonkey/js/src/build_OPT.OBJ/dist/bin/js run_we.js'"
-          % (WARMUP_DIR, WARMUP_DIR)
+    "v8": "sh -c 'cd %s/extbench/octane && LD_LIBRARY_PATH=%s %s/work/v8/out/native/d8 run_we.js'"
+          % (WARMUP_DIR, LD_LIBRARY_PATH, WARMUP_DIR),
 }
+
+if sys.platform.startswith("linux"):
+    JAVASCRIPT_VMS["spidermonkey"] = (
+	"sh -c 'cd %s/extbench/octane && LD_LIBRARY_PATH=%s "
+	"%s/work/spidermonkey/js/src/build_OPT.OBJ/dist/bin/js run_we.js'") % \
+	    (WARMUP_DIR, LD_LIBRARY_PATH, WARMUP_DIR)
 
 ITERATIONS = 2000
 PROCESSES = 30


### PR DESCRIPTION
Fixes crashes on OpenBSD.

Tested on OpenBSD, but can you try testing this branch on Linux. I don't have the VMs built at the moment (also comment out v8 to check the spidermonkey invocation too).

Thanks