### PR TITLE
Use a microsecond timer on Spidermonkey.

### DIFF
--- a/patches/octane.diff
+++ b/patches/octane.diff
@@ -1,3 +1,15 @@
+diff --git a/base.js b/base.js
+index 9d6e3de..9542e11 100644
+--- a/base.js
++++ b/base.js
+@@ -30,6 +30,7 @@
+ var performance = performance || {};
+ performance.now = (function() {
+   return performance.now       ||
++         dateNow               ||
+          performance.mozNow    ||
+          performance.msNow     ||
+          performance.oNow      ||
 diff --git a/pdfjs.js b/pdfjs.js
 index 7953754..2d5584d 100644
 --- a/pdfjs.js


### PR DESCRIPTION
In essence, we use Octane's existing monkey-patching to insert SpiderMonkey's `dateNow` timer, which seems to be much higher resolution than its `mozNow` timer (why? dunno).

With this we get timings like this from SpiderMonkey:

```
0,Richards,0.7687880859375,0.74989697265625,0.745474853515625,0.746031005859375,
0.74589599609375,0.745971923828125,0.74589599609375,0.746054931640625,0.74631396484375,0.74574609375
```

and this from V8:

```
0,Richards,0.835802,0.86226,0.8229379999999999,0.851886,0.8878850000000002,0.8227069999999994,0.8238940000000002,0.822116,0.8220059999999994,0.8216729999999989,0.821610999999999,0.8220190000000002,0.8220570000000007,0.8210059999999994,0.8218099999999995,0.8214639999999999,0.8217029999999995,0.8213130000000001,0.8215949999999993,0.8222829999999994,0.8295579999999973,0.9181180000000022,0.840742000000002,0.8250130000000026
```

So, in both cases, we get microsecond timings (i.e. to 6DP in seconds).