### PR TITLE
Ensure the external suites use the same environment as Krun.

### DIFF
--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -3,6 +3,7 @@
 import csv, os, socket, sys, time
 from decimal import Decimal
 from krun.platform import detect_platform
+from krun.config import Config
 from krun.util import run_shell_cmd_bench
 from krun.vm_defs import find_internal_jvmci_java_home
 
@@ -33,7 +34,9 @@ else:
     SSH_DO_COPY = False
 
 def main():
-    platform = detect_platform(None, None)
+    platform = detect_platform(None, Config())
+    platform.check_preliminaries()
+    platform.sanity_checks()
     for jvm_name, jvm_cmd in JAVA_VMS.items():
         csvp = "dacapo.%s.results" % jvm_name
         with open(csvp, 'wb') as csvf:
@@ -73,6 +76,7 @@ def main():
                     assert len(output) == ITERATIONS
                     writer.writerow([process, benchmark] + output)
                 sys.stdout.write("\n")
+    platform.save_power()
 
 
 if __name__ == '__main__':

--- a/extbench/runoctane.py
+++ b/extbench/runoctane.py
@@ -3,6 +3,7 @@
 import csv, os, socket, sys, time
 from decimal import Decimal
 from krun.platform import detect_platform
+from krun.config import Config
 from krun.util import run_shell_cmd_bench
 
 WARMUP_DIR = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
@@ -31,7 +32,9 @@ ITERATIONS = 2000
 PROCESSES = 30
 
 def main():
-    platform = detect_platform(None, None)
+    platform = detect_platform(None, Config())
+    platform.check_preliminaries()
+    platform.sanity_checks()
     for jsvm_name, jsvm_cmd in JAVASCRIPT_VMS.items():
         csvp = "octane.%s.results" % jsvm_name
         with open(csvp, 'wb') as csvf:
@@ -75,6 +78,7 @@ def main():
                 assert len(times) == ITERATIONS
                 writer.writerow([process, bench_name] + times)
             sys.stdout.write("\n")
+    platform.save_power()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This small change ensures that the same checks that krun makes (cpu governor, scaler, alsr settings, ...) are used for Octane and Dacapo. This is in response to the fact that it is hard to have a consistent setup for octane/dacapo (since they are not Krunified) and it is easy to forget to set the max clock speed.

Tested on OpenBSD by checking apm status at various points in the runner script.

Needs test on Linux, but review can go ahead.