### PR TITLE
Bring tables up to date with new classifier

### DIFF
--- a/bin/mark_changepoints_in_json
+++ b/bin/mark_changepoints_in_json
@@ -146,7 +146,8 @@ def main(in_files, half_bound, delta, steady_state):
         krun_data[filename]['changepoints'] = changepoints
         krun_data[filename]['changepoint_means'] = changepoint_means
         krun_data[filename]['classifications'] = classifications
-        krun_data[filename]['steady_state_expected'] = steady_state
+        krun_data[filename]['classifier'] = { 'half_bound':half_bound,
+                                              'delta':delta, 'steady':steady_state }
         new_filename = create_output_filename(filename)
         print 'Writing out: %s' % new_filename
         write_krun_results_file(krun_data[filename], new_filename)

--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -18,6 +18,10 @@ from warmup.latex import format_median_error, get_latex_symbol_map
 from warmup.statistics import bootstrap_confidence_interval
 
 
+SKIP_OUTER_KEYS = ['audit', 'reboots', 'window_size', 'mperf_counts', 'aperf_counts',
+                   'eta_estimates', 'starting_temperatures', 'core_cycle_counts',
+                   'config', 'error_flag']
+
 VM_NAMES_MAP = {
     'JRubyTruffle': 'JRuby+Truffle',
     'Hotspot': 'HotSpot'
@@ -41,7 +45,7 @@ TABLE_HEADINGS2 = '&&\\multicolumn{1}{c}{Class.} &\\multicolumn{1}{c}{iter (\#)}
 
 BLANK_CELL = '\\begin{minipage}[c][\\blankheight]{0pt}\\end{minipage}'
 
-def main(data_dcts, window_size, latex_file, with_preamble=False):
+def main(data_dcts, half_bound, delta, steady_state, latex_file, with_preamble=False):
     # machine -> vm -> bench -> summary
     summary_data = dict()
 
@@ -70,19 +74,39 @@ def main(data_dcts, window_size, latex_file, with_preamble=False):
 
             # Get information for all p_execs of this key.
             categories = list()
-            last_segment_means = list()
-            last_changepoints = list()
+            steady_state_means = list()
+            steady_iters = list()
             time_to_steadys = list()
             n_pexecs = len(data_dcts[machine]['wallclock_times'][key])
             for p_exec in xrange(n_pexecs):
                 categories.append(data_dcts[machine]['classifications'][key][p_exec])
-                last_segment_means.append(data_dcts[machine]['changepoint_means'][key][p_exec][-1])
+                # Next we calculate the iteration at which a steady state was
+                # reached, it's average segment mean and the time to reach a
+                # steady state. However, the last segment may be equivalent to
+                # its adjacent segments, so we first need to know which segments
+                # are steady-state segments.
+                first_steady_segment = len(data_dcts[machine]['changepoint_means'][key][p_exec]) - 1
+                num_steady_segments = 1
+                last_segment_mean = data_dcts[machine]['changepoint_means'][key][p_exec][-1]
+                lower_bound = min(last_segment_mean * (1.0 - half_bound), last_segment_mean - delta)
+                upper_bound = max(last_segment_mean * (1.0 + half_bound), last_segment_mean + delta)
+                for index in xrange(len(data_dcts[machine]['changepoint_means'][key][p_exec]) - 2, -1, -1):
+                    current_segment_mean = data_dcts[machine]['changepoint_means'][key][p_exec][index]
+                    if current_segment_mean >= lower_bound and current_segment_mean <= upper_bound:
+                        first_steady_segment -= 1
+                        num_steady_segments += 1
+                    else:
+                        break
+                steady_state_mean = (math.fsum(data_dcts[machine]['changepoint_means'][key][p_exec][first_steady_segment:])
+                                     / float(num_steady_segments))
+                steady_state_means.append(steady_state_mean)
                 # Not all process execs have changepoints. However, all
                 # p_execs will have one or more segment mean.
                 if data_dcts[machine]['changepoints'][key][p_exec]:
-                    last_changepoints.append(data_dcts[machine]['changepoints'][key][p_exec][-1])
+                    steady_iter = data_dcts[machine]['changepoints'][key][p_exec][first_steady_segment - 1]
+                    steady_iters.append(steady_iter)
                     to_steady = 0.0
-                    for index in xrange(data_dcts[machine]['changepoints'][key][p_exec][-1]):
+                    for index in xrange(steady_iter):
                         to_steady += data_dcts[machine]['wallclock_times'][key][p_exec][index]
                     time_to_steadys.append(to_steady)
                 else:  # Flat execution, no changepoints.
@@ -94,31 +118,37 @@ def main(data_dcts, window_size, latex_file, with_preamble=False):
                 # Consistent benchmark, but some process execs failed with error.
                 reported_category = ' %s\\scriptsize{($%d$)}' % \
                                     (STYLE_SYMBOLS[categories[0]], len(categories))
-            else:
-                reported_category = STYLE_SYMBOLS['inconsistent']
+            elif set(categories) == set(['flat', 'warmup']):
+                reported_category = STYLE_SYMBOLS['good inconsistent']
+                cat_counts = list()
+                for category, occurences in Counter(categories).most_common():
+                    cat_counts.append('$%d$%s' % (occurences, STYLE_SYMBOLS[category]))
+                reported_category += ' \\scriptsize(%s)' % ', '.join(cat_counts)
+            else:  # Bad inconsistent.
+                reported_category = STYLE_SYMBOLS['bad inconsistent']
                 cat_counts = list()
                 for category, occurences in Counter(categories).most_common():
                     cat_counts.append('$%d$%s' % (occurences, STYLE_SYMBOLS[category]))
                 reported_category += ' \\scriptsize(%s)' % ', '.join(cat_counts)
 
             if STYLE_SYMBOLS['no steady state'] in reported_category:
-                mean_last_segment = ''
-                mean_last_cpt = ''
+                mean_steady = ''
+                mean_steady_iter = ''
                 time_to_steady = ''
             else:
-                median, error = bootstrap_confidence_interval(last_segment_means)
-                mean_last_segment = format_median_error(median, error)
-                if last_changepoints:
-                    median, error = bootstrap_confidence_interval(last_changepoints)
-                    mean_last_cpt = format_median_error(median, error, as_integer=True)
+                median_s, error_s = bootstrap_confidence_interval(steady_state_means)
+                mean_steady = format_median_error(median_s, error_s)
+                if steady_iters:
+                    median_iter, error_iter = bootstrap_confidence_interval(steady_iters)
+                    mean_steady_iter = format_median_error(median_iter, error_iter, as_integer=True)
                     median_t, error_t = bootstrap_confidence_interval(time_to_steadys)
                     time_to_steady = format_median_error(median_t, error_t, brief=True)
                 else:  # No changepoints in any process executions.
-                    mean_last_cpt = format_median_error(0, 0, as_integer=True)
+                    mean_steady_iter = format_median_error(0, 0, as_integer=True)
                     time_to_steady = ''
             # Add summary for this benchmark.
             summary_data[vm][bench] = {'style': reported_category,
-                'last_cpt': mean_last_cpt, 'last_mean': mean_last_segment,
+                'last_cpt': mean_steady_iter, 'last_mean': mean_steady,
                 'time_to_steady_state':time_to_steady}
     # Write out results.
     write_results_as_latex(machine, list(sorted(all_benchs)), summary_data,
@@ -154,7 +184,7 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
     with open(tex_file, 'w') as fp:
         if with_preamble:
             fp.write(preamble(TITLE))
-            fp.write('%s' % get_latex_symbol_map())
+            fp.write('\centering %s' % get_latex_symbol_map())
             fp.write('\n\n\n')
             fp.write('\\begin{table*}[t]\n')
             fp.write('\\centering\n')
@@ -249,7 +279,7 @@ def get_data_dictionaries(json_files):
     dictionaries of machine name -> JSON values.
     """
     data_dictionary = dict()
-    steady_state = None
+    classifier = None  # steady, delta, half_bound values used by classifer.
     for filename in json_files:
         assert os.path.exists(filename), 'File %s does not exist.' % filename
         print 'Loading: %s' % filename
@@ -264,9 +294,9 @@ def get_data_dictionaries(json_files):
             data_dictionary[machine_name] = data
         else:  # We may have two datasets from the same machine.
             for outer_key in data:
-                if outer_key == 'audit' or outer_key == 'reboots':
+                if outer_key in SKIP_OUTER_KEYS:
                     continue
-                elif outer_key == 'steady_state_expected':
+                elif outer_key == 'classifier':
                     assert data_dictionary[machine_name][outer_key] == data[outer_key]
                     continue
                 for key in data[outer_key]:
@@ -274,13 +304,14 @@ def get_data_dictionaries(json_files):
                     if key not in data_dictionary[machine_name][outer_key]:
                         data_dictionary[machine_name][outer_key][key] = dict()
                     data_dictionary[machine_name][outer_key][key] = data[outer_key][key]
-        if steady_state is None:
-            steady_state = data['steady_state_expected']
+        if classifier is None:
+            classifier = data['classifier']
         else:
-            assert steady_state == data['steady_state_expected'], \
-                   ('Cannot summarise categories generated with different' +
-                    ' steady-state-expected values.')
-    return steady_state, data_dictionary
+            assert classifier == data['classifier'], \
+                   ('Cannot summarise categories generated with different '
+                    'command-line options for steady-state-expected, half_bound '
+                    'or delta. Please re-run the mark_changepoints_in_json script.')
+    return classifier, data_dictionary
 
 
 def create_cli_parser():
@@ -307,7 +338,8 @@ def create_cli_parser():
 if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
-    steady_state, data_dcts = get_data_dictionaries(options.json_files[0])
+    classifier, data_dcts = get_data_dictionaries(options.json_files[0])
     if options.with_preamble:
         print 'Writing out full document, with preamble.'
-    main(data_dcts, steady_state, options.latex_file, options.with_preamble)
+    main(data_dcts, classifier['half_bound'], classifier['delta'], classifier['steady'],
+         options.latex_file, options.with_preamble)

--- a/bin/table_classification_summaries_others
+++ b/bin/table_classification_summaries_others
@@ -27,9 +27,11 @@ TABLE_HEADINGS2 = '&&\\multicolumn{1}{c}{Class.} &\\multicolumn{1}{c}{iter (\#)}
 
 BLANK_CELL = '\\begin{minipage}[c][\\blankheight]{0pt}\\end{minipage}'
 
-SKIP_OUTER_KEYS = ['audit', 'reboots', 'window_size']
+SKIP_OUTER_KEYS = ['audit', 'reboots', 'window_size', 'mperf_counts', 'aperf_counts',
+                   'eta_estimates', 'starting_temperatures', 'core_cycle_counts',
+                   'config', 'error_flag']
 
-def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
+def main(data_dcts, half_bound, delta, steady_state, latex_file, num_splits, with_preamble=False):
     # machine -> vm -> bench -> summary
     summary_data = dict()
 
@@ -58,19 +60,39 @@ def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
 
             # Get information for all p_execs of this key.
             categories = list()
-            last_segment_means = list()
-            last_changepoints = list()
+            steady_state_means = list()
+            steady_iters = list()
             time_to_steadys = list()
             n_pexecs = len(data_dcts[machine]['wallclock_times'][key])
             for p_exec in xrange(n_pexecs):
                 categories.append(data_dcts[machine]['classifications'][key][p_exec])
-                last_segment_means.append(data_dcts[machine]['changepoint_means'][key][p_exec][-1])
+                # Next we calculate the iteration at which a steady state was
+                # reached, it's average segment mean and the time to reach a
+                # steady state. However, the last segment may be equivalent to
+                # its adjacent segments, so we first need to know which segments
+                # are steady-state segments.
+                first_steady_segment = len(data_dcts[machine]['changepoint_means'][key][p_exec]) - 1
+                num_steady_segments = 1
+                last_segment_mean = data_dcts[machine]['changepoint_means'][key][p_exec][-1]
+                lower_bound = min(last_segment_mean * (1.0 - half_bound), last_segment_mean - delta)
+                upper_bound = max(last_segment_mean * (1.0 + half_bound), last_segment_mean + delta)
+                for index in xrange(len(data_dcts[machine]['changepoint_means'][key][p_exec]) - 2, -1, -1):
+                    current_segment_mean = data_dcts[machine]['changepoint_means'][key][p_exec][index]
+                    if current_segment_mean >= lower_bound and current_segment_mean <= upper_bound:
+                        first_steady_segment -= 1
+                        num_steady_segments += 1
+                    else:
+                        break
+                steady_state_mean = (math.fsum(data_dcts[machine]['changepoint_means'][key][p_exec][first_steady_segment:])
+                                     / float(num_steady_segments))
+                steady_state_means.append(steady_state_mean)
                 # Not all process execs have changepoints. However, all
                 # p_execs will have one or more segment mean.
                 if data_dcts[machine]['changepoints'][key][p_exec]:
-                    last_changepoints.append(data_dcts[machine]['changepoints'][key][p_exec][-1])
+                    steady_iter = data_dcts[machine]['changepoints'][key][p_exec][first_steady_segment - 1]
+                    steady_iters.append(steady_iter)
                     to_steady = 0.0
-                    for index in xrange(data_dcts[machine]['changepoints'][key][p_exec][-1]):
+                    for index in xrange(steady_iter):
                         to_steady += data_dcts[machine]['wallclock_times'][key][p_exec][index]
                     time_to_steadys.append(to_steady)
                 else:  # Flat execution, no changepoints.
@@ -82,31 +104,37 @@ def main(data_dcts, window_size, latex_file, num_splits, with_preamble=False):
                 # Consistent benchmark, but some process execs failed with error.
                 reported_category = ' %s\\scriptsize{($%d$)}' % \
                                     (STYLE_SYMBOLS[categories[0]], len(categories))
-            else:
-                reported_category = STYLE_SYMBOLS['inconsistent']
+            elif set(categories) == set(['flat', 'warmup']):
+                reported_category = STYLE_SYMBOLS['good inconsistent']
+                cat_counts = list()
+                for category, occurences in Counter(categories).most_common():
+                    cat_counts.append('$%d$%s' % (occurences, STYLE_SYMBOLS[category]))
+                reported_category += ' \\scriptsize(%s)' % ', '.join(cat_counts)
+            else:  # Bad inconsistent.
+                reported_category = STYLE_SYMBOLS['bad inconsistent']
                 cat_counts = list()
                 for category, occurences in Counter(categories).most_common():
                     cat_counts.append('$%d$%s' % (occurences, STYLE_SYMBOLS[category]))
                 reported_category += ' \\scriptsize(%s)' % ', '.join(cat_counts)
 
             if STYLE_SYMBOLS['no steady state'] in reported_category:
-                mean_last_segment = ''
-                mean_last_cpt = ''
+                mean_steady = ''
+                mean_steady_iter = ''
                 time_to_steady = ''
             else:
-                median, error = bootstrap_confidence_interval(last_segment_means)
-                mean_last_segment = format_median_error(median, error)
-                if last_changepoints:
-                    median, error = bootstrap_confidence_interval(last_changepoints)
-                    mean_last_cpt = format_median_error(median, error, as_integer=True)
+                median_s, error_s = bootstrap_confidence_interval(steady_state_means)
+                mean_steady = format_median_error(median_s, error_s)
+                if steady_iters:
+                    median_iter, error_iter = bootstrap_confidence_interval(steady_iters)
+                    mean_steady_iter = format_median_error(median_iter, error_iter, as_integer=True)
                     median_t, error_t = bootstrap_confidence_interval(time_to_steadys)
                     time_to_steady = format_median_error(median_t, error_t, brief=True)
                 else:  # No changepoints in any process executions.
-                    mean_last_cpt = format_median_error(0, 0, as_integer=True)
+                    mean_steady_iter = format_median_error(0, 0, as_integer=True)
                     time_to_steady = ''
             # Add summary for this benchmark.
             summary_data[vm][bench] = {'style': reported_category,
-                'last_cpt': mean_last_cpt, 'last_mean': mean_last_segment,
+                'last_cpt': mean_steady_iter, 'last_mean': mean_steady,
                 'time_to_steady_state':time_to_steady}
     # Write out results.
     write_results_as_latex(machine, list(sorted(all_benchs)), summary_data,
@@ -142,7 +170,7 @@ def write_results_as_latex(machine, all_benchs, summary, steady_state, tex_file,
     with open(tex_file, 'w') as fp:
         if with_preamble:
             fp.write(preamble(TITLE))
-            fp.write('%s' % get_latex_symbol_map())
+            fp.write('\centering %s' % get_latex_symbol_map())
             fp.write('\n\n\n')
             fp.write('\\begin{table*}[t]\n')
             fp.write('\\centering\n')
@@ -230,7 +258,7 @@ def get_data_dictionaries(json_files):
     dictionaries of machine name -> JSON values.
     """
     data_dictionary = dict()
-    steady_state = None
+    classifier = None  # steady, delta, half_bound values used by classifer.
     for filename in json_files:
         assert os.path.exists(filename), 'File %s does not exist.' % filename
         print 'Loading: %s' % filename
@@ -247,7 +275,7 @@ def get_data_dictionaries(json_files):
             for outer_key in data:
                 if outer_key in SKIP_OUTER_KEYS:
                     continue
-                elif outer_key == 'steady_state_expected':
+                elif outer_key == 'classifier':
                     assert data_dictionary[machine_name][outer_key] == data[outer_key]
                     continue
                 for key in data[outer_key]:
@@ -255,13 +283,14 @@ def get_data_dictionaries(json_files):
                     if key not in data_dictionary[machine_name][outer_key]:
                         data_dictionary[machine_name][outer_key][key] = dict()
                     data_dictionary[machine_name][outer_key][key] = data[outer_key][key]
-        if steady_state is None:
-            steady_state = data['steady_state_expected']
+        if classifier is None:
+            classifier = data['classifier']
         else:
-            assert steady_state == data['steady_state_expected'], \
-                   ('Cannot summarise categories generated with different' +
-                    ' steady-state-expected values.')
-    return steady_state, data_dictionary
+            assert classifier == data['classifier'], \
+                   ('Cannot summarise categories generated with different '
+                    'command-line options for steady-state-expected, half_bound '
+                    'or delta. Please re-run the mark_changepoints_in_json script.')
+    return classifier, data_dictionary
 
 
 def create_cli_parser():
@@ -291,9 +320,8 @@ def create_cli_parser():
 if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
-    steady_state, data_dcts = get_data_dictionaries(options.json_files[0])
+    classifier, data_dcts = get_data_dictionaries(options.json_files[0])
     if options.with_preamble:
         print 'Writing out full document, with preamble.'
-    main(data_dcts, steady_state, options.latex_file, options.num_splits,
-         options.with_preamble)
-
+    main(data_dcts, classifier['half_bound'], classifier['delta'], classifier['steady'],
+         options.latex_file, options.num_splits, options.with_preamble)

--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -4,7 +4,8 @@ STYLE_SYMBOLS = {  # Requires \usepackage{amssymb} and \usepackage{sparklines}
     'no steady state': '\\nosteadystate',
     'slowdown': '\\slowdown',
     'warmup': '\\warmup',
-    'inconsistent': '\\inconsistent',
+    'good inconsistent': '\\goodinconsistent',
+    'bad inconsistent': '\\badinconsistent',
 }
 
 
@@ -87,17 +88,29 @@ $\\begin{array}{rr}
        1.0 0.8
        /%
 \\end{sparkline}\\xspace}
-\\DeclareRobustCommand{\\inconsistent}{%
+\\DeclareRobustCommand{\\badinconsistent}{%
 \\setlength{\\sparklinethickness}{0.4pt}%
 \\begin{sparkline}{1.5}
-\\spark 0.0 0.55
-       1.0 0.55
+\\spark 0.1 0.4
+       0.9 0.4
        /%
-\\spark 0.0 0.2
-       1.0 0.2
+\\spark 0.1 0.2
+       0.9 0.2
        /%
-\\spark 0.1 0.75
+\\spark 0.1 0.6
        0.9 0.0
+       /%
+\\end{sparkline}\\xspace}
+\\DeclareRobustCommand{\\goodinconsistent}{%
+\\setlength{\\sparklinethickness}{0.4pt}%
+\\begin{sparkline}{1.5}
+\\spark 0.0 0.8
+       0.5 0.8
+       0.5 0.0
+       1.0 0.0
+       /%
+\\spark 0.0 0.4
+       1.0 0.4
        /%
 \\end{sparkline}\\xspace}
 """


### PR DESCRIPTION
This PR updates the table scripts in two ways:

  1. to use the new "good" and "bad" inconsistent symbols
  2. to take account of the new classifier, which can now decide that a steady state has been reached *before* the last segment

The commits need quite a bit of squashing.

### Octane 0.7 test case

  * [Table as per master branch](https://dl.dropbox.com/s/t447w7wr2vsg3x3/master_branch_octane_table.pdf?dl=0)
  * [Table as per this PR](https://dl.dropbox.com/s/aelwfbnf6qn0yw7/new_table.pdf?dl=0)
  * [V8 plots](https:/dl.dropbox.com/s/4jmq3lgtmg1w5ic/octane_0_7_v8.pdf?dl=0)
  * [Spidermonkey plots](https://dl.dropbox.com/s/c6urdoui5x75xm6/octane_0_7_spidermonkey.pdf?dl=0)

### Bencher 3 warmup test case

  * [Table as per master branch](https://dl.dropbox.com/s/a7h3da1pw5bqaca/bencher3_master_branch_table.pdf?dl=0)
  * [Table as per this PR](https://dl.dropbox.com/s/vigoxoed4fh3n66/bencher3_new_table.pdf?dl=0)
  * [Plots](https://dl.dropbox.com/s/jqqolwcgpbimqvj/bencher3_plots.pdf?dl=0)

### Bencher 5 warmup test case

  * [Table as per master branch](https://dl.dropbox.com/s/z3c9ir6s3rpmxdf/bencher5_master_branch_table.pdf?dl=0)
  * [Table as per this PR](https://dldropbox.com/s/uj0qurol0cr3r6x/bencher5_new_table.pdf?dl=0)
  * [Plots](https://dl.dropbox.com/s/ot2ooxzkarxdzic/bencher5_plots.pdf?dl=0)

### Bencher 6 warmup test case

  * [Table as per master branch](https://dl.dropbox.com/s/rmdmgsrv4h3vx1p/bencher6_master_branch_table.pdf?dl=0)
  * [Table as per this PR](https://dl.dropbox.com/s/61shtjknoh1mimh/bencher6_new_table.pdf?dl=0)
  * [Plots](https://dl.dropbox.com/s/vj61gv0m8i6pc5p/bencher6_plots.pdf?dl=0)