### PR TITLE
Html output from bin/warmup_stats

### DIFF
--- a/bin/warmup_stats
+++ b/bin/warmup_stats
@@ -12,7 +12,9 @@ from distutils.spawn import find_executable
 from logging import debug, error, info, warn
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import csv_to_krun_json, parse_krun_file_with_changepoints
-from warmup.summary_statistics import collect_summary_statistics, convert_to_latex, write_latex_table
+from warmup.summary_statistics import collect_summary_statistics, convert_to_latex
+from warmup.summary_statistics import write_html_table, write_latex_table
+
 
 # We use a custom install of rpy2, relative to the top-level of the repo.
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -271,7 +273,8 @@ def main(options):
         debug('Running: %s' % ' '.join(cli))
         _ = subprocess.check_output(' '.join(cli), shell=True)
     if options.output_html:
-        raise NotImplementedError()
+        info('Generating HTML table.')
+        write_html_table(summary, options.output_html)
 
 
 if __name__ == '__main__':

--- a/warmup/html.py
+++ b/warmup/html.py
@@ -1,0 +1,38 @@
+HTML_TABLE_TEMPLATE = """<h2>Results for %s</h2>
+<table>
+<tr>
+<th>Benchmark</th>
+<th>Classification</th>
+<th>Steady iteration (&#35;)</th>
+<th>Steady iteration (secs)</th>
+<th>Steady performance (secs)</th>
+</tr>
+%s
+</table>
+"""  # VM name, table rows.
+
+
+HTML_PAGE_TEMPLATE = """<html>
+<head>
+<title>Benchmark results</title>
+<style>
+body               { background-color: white;
+                     border-collapse: collapse; }
+table              { width: 100%%; }
+td                 { white-space: pre-wrap;
+                     word-wrap: break-word;
+                     text-align: left;
+                     padding: 8px; }
+th                 { background-color: black;
+                     color: white;
+                     text-align: left;
+                     padding: 8px; }
+tr:nth-child(even) { background-color: "#f2f2f2"; }
+</style>
+</head>
+<body>
+<h1>Benchmark results</h1>
+%s
+</body>
+</html>
+"""  # Strings from HTML_TABLE_TEMPLATE.


### PR DESCRIPTION
This PR adds functionality for the `--output-html FILENAME` options in `bin/warmup_stats`.

The current output looks like this:

![first_html_output](https://cloud.githubusercontent.com/assets/97674/23281165/1b3d5006-fa14-11e6-91b5-9ae95f184e25.png)
