### PR TITLE
Remove 'could not classify' from legend.

### DIFF
--- a/warmup/latex.py
+++ b/warmup/latex.py
@@ -3,7 +3,6 @@ _NUMBERS = {0:'zero', 1:'one', 2:'two', 3:'three', 4:'four', 5:'five',
 
 
 STYLE_SYMBOLS = {  # Requires \usepackage{amssymb} and \usepackage{sparklines}
-    'could not classify': '$\\bot$',
     'flat': '\\flatc',
     'no steady state': '\\nosteadystate',
     'slowdown': '\\slowdown',


### PR DESCRIPTION
 mark_changepoints script now throws an exception if it cannot classify, so 'could not classify' cannot show up in any tables. This changes the legend in the table documents, not the table itself.

### Test case

  * Was: [old_b7_table.pdf](https://github.com/softdevteam/warmup_experiment/files/842155/old_b7_table.pdf)
  * Now: [bencher7_table.pdf](https://github.com/softdevteam/warmup_experiment/files/842161/bencher7_table.pdf)
