### PR TITLE
Disable luindex (and other related things)

### DIFF
--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -61,7 +61,13 @@ def main():
 
                     stdout, stderr, rc = run_shell_cmd_bench(
                         "%s -jar %s %s -n %s" % (jvm_cmd, JAR, benchmark,
-                                                 ITERATIONS + 1), platform)
+                                                 ITERATIONS + 1), platform, failure_fatal=False)
+                    if rc != 0:
+                        sys.stdout.write(stdout + "\n")
+                        sys.stdout.flush()
+                        sys.stderr.write(stderr + "\n")
+                        sys.stderr.flush()
+                        continue
                     output = []
                     for line in stderr.splitlines():
                         if not line.startswith("====="):

--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -13,8 +13,9 @@ ITERATIONS = 2000
 PROCESSES = 30
 
 # broken: batik, eclipse, tomcat
-WORKING_BENCHS = ['avrora', 'fop', 'h2', 'jython', 'luindex', 'lusearch',
-                  'pmd', 'sunflow', 'tradebeans', 'xalan']
+WORKING_BENCHS   = ['avrora', 'fop', 'h2', 'jython', 'luindex', 'lusearch',
+                    'pmd', 'sunflow', 'tradebeans', 'tradesoap', 'xalan']
+DISABLE_ON_GRAAL = set(["luindex", "tradebeans", "tradesoap"])
 
 JAR = os.path.join(os.path.dirname(__file__), "dacapo-9.12-bach.jar")
 
@@ -44,6 +45,8 @@ def main():
             writer = csv.writer(csvf)
             writer.writerow(['processnum', 'benchmark'] + range(ITERATIONS))
             for benchmark in WORKING_BENCHS:
+                if jvm_name == "graal" and benchmark in DISABLE_ON_GRAAL:
+                    continue
                 sys.stdout.write("  %s:" % benchmark)
                 for process in range(PROCESSES):
                     sys.stdout.write(" %s" % str(process))


### PR DESCRIPTION
*Needs testing before merging*

This is three things in one, so it's best to read the individual commits.

This needs at least light testing before merging. Edd, can you look into that please? I'd suggest reducing `ITERATIONS` to (say) 10 and `PROCESSES` to (say) 3, which shouldn't take *too* long to execute.