### PR TITLE
Remove Seaborn as a dependency.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@
 ## Optional requirements
 
   * PyPy (will allow some code here to run faster)
-  * Python modules required for plotting: matplotlib, seaborn
+  * Python modules required for plotting: matplotlib
   * Required for generating LaTeX tables: a LaTeX distribution which provides
     pdflatex, and the following packages: amsmath, amssymb, booktabs, calc,
     geometry, mathtools, multicol, multirow, rotating, sparklines, xspace.
@@ -33,7 +33,7 @@ Debian-based systems:
 ```sh
 $ sudo apt-get install build-essential python2.7 pypy bzip2 libssl-dev \
        pkg-config libcurl4-openssl-dev python-numpy python-matplotlib \
-       python-seaborn python-pip texlive-latex-extra wget xorg-dev \
+       python-pip texlive-latex-extra wget xorg-dev \
        libreadline-dev libbz2-dev liblzma-dev libpcre3-dev gfortran
 $ ./build_stats.sh
 ```

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -12,7 +12,6 @@ import numpy
 import numpy.random
 import os
 import os.path
-import seaborn
 import sys
 
 from matplotlib import gridspec, pyplot
@@ -23,14 +22,14 @@ from warmup.krun_results import pretty_print_machine, read_krun_results_file
 from warmup.outliers import get_window
 from warmup.plotting import add_inset_to_axis, add_margin_to_axes
 from warmup.plotting import collide_rect, compute_grid_offsets, format_yticks_scientific
-from warmup.plotting import get_unified_yrange, style_axis, zoom_y_min, zoom_y_max
+from warmup.plotting import get_unified_yrange, style_axis, STYLE_DICT, zoom_y_min, zoom_y_max
 from warmup.vm_instruments import INSTRUMENTATION_PARSERS
 
-seaborn.set_palette('colorblind')
-seaborn.set_style('whitegrid', {'lines.linewidth': 1.0, 'axes.linewidth': 1.0})
-seaborn.set_context('paper')
-
 pyplot.figure(tight_layout=True)
+
+# Set matplotlib styles, similar to Seaborn 'whitegrid'.
+for style in STYLE_DICT:
+    matplotlib.rcParams[style] = STYLE_DICT[style]
 
 # Configures border and spacing of subplots.
 # Here we just make it more space efficient for the paper
@@ -61,6 +60,7 @@ GRID_MINOR_Y_DIVS_SMALLER_PLOTS = 4
 GRID_MAJOR_Y_DIVS_SMALLER_PLOTS = 2
 
 LINE_COLOUR = 'k'
+MEDIAN_COLOUR = '#0072B2'
 FILL_ALPHA = 0.2
 
 # line widths, measured in pts
@@ -120,17 +120,8 @@ ZOOM_OUTLIER_SIZE = 8
 TICK_FONTSIZE = 8
 TITLE_FONT_SIZE = 10
 AXIS_FONTSIZE = 8
-BASE_FONTSIZE = 8
 LEGEND_FONTSIZE = 10
 YTICK_FORMAT = '%.4f'
-
-
-FONT = {
-    'family': 'sans',
-    'weight': 'regular',
-    'size': BASE_FONTSIZE,
-}
-matplotlib.rc('font', **FONT)
 
 MAX_SUBPLOTS_PER_ROW = 2
 EXPORT_SIZE_INCHES = [12, 10]
@@ -519,7 +510,7 @@ class ProcessExecChart(object):
 
     def plot_median(self, axis):
         axis.plot(self.iterations, self.medians, label='Median', zorder=ZORDER_MEDIAN,
-                  linewidth=PLOT_LINE_WIDTH)
+                  linewidth=PLOT_LINE_WIDTH, color=MEDIAN_COLOUR)
 
     def plot_tukey_interval(self, axis):
         axis.fill_between(self.iterations, self.tukey_interval[0], self.tukey_interval[1],

--- a/bin/plot_outliers_by_threshold
+++ b/bin/plot_outliers_by_threshold
@@ -11,11 +11,14 @@ from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.ticker import FormatStrFormatter, FuncFormatter, MaxNLocator
 import os
 import os.path
-import seaborn
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from warmup.plotting import add_margin_to_axes, compute_grid_offsets, style_axis
+from warmup.plotting import add_margin_to_axes, compute_grid_offsets, style_axis, STYLE_DICT
+
+# Set matplotlib styles, similar to Seaborn 'whitegrid'.
+for style in STYLE_DICT:
+    matplotlib.rcParams[style] = STYLE_DICT[style]
 
 PDF_FILENAME = 'outliers_per_threshold.pdf'
 WINDOWS = [25, 50, 100, 200, 300, 400]
@@ -51,10 +54,6 @@ FILL_ALPHA = 0.2
 
 MAX_SUBPLOTS_PER_ROW = 2
 MARKERSIZE=4
-
-seaborn.set_palette('colorblind')
-seaborn.set_style('whitegrid', {'lines.linewidth': 1.0, 'axes.linewidth': 1.0})
-seaborn.set_context('paper')
 
 plt.figure(tight_layout=True)
 

--- a/bin/warmup_stats
+++ b/bin/warmup_stats
@@ -149,13 +149,9 @@ def check_environment(need_outliers=True, need_changepoints=True, need_latex=Tru
     if need_plots:
         try:
             import matplotlib
-        except ImportError:
-            fatal('Please install the Python matplotlib library to generate plots.')
-        try:
             matplotlib.use('Agg')
-            import seaborn
         except ImportError:
-            fatal('Please install the Python seaborn library to generate plots.')
+            fatal('Please install the Python matplotlib library, with Agg backend, to generate plots.')
     return python_path, pypy_path, pdflatex_path, r_path
 
 

--- a/warmup/plotting.py
+++ b/warmup/plotting.py
@@ -4,13 +4,40 @@ import numpy
 from matplotlib import pyplot
 from matplotlib.ticker import ScalarFormatter, FormatStrFormatter
 
-SPINE_LINESTYLE = 'solid'
-SPINE_LINEWIDTH = 1
-
 ZOOM_PERCENTILE_MIN = 10.0
 ZOOM_PERCENTILE_MAX = 90.0
 
 ZORDER_GRID = 1
+
+DARK_GRAY = '.15'
+LIGHT_GRAY = '.8'
+BASE_FONTSIZE = 8
+
+STYLE_DICT = {
+    'figure.facecolor': 'white',
+    'text.color': DARK_GRAY,
+    'axes.labelcolor': DARK_GRAY,
+    'legend.frameon': False,
+    'legend.numpoints': 1,
+    'legend.scatterpoints': 1,
+    'xtick.direction': 'out',
+    'ytick.direction': 'out',
+    'xtick.color': DARK_GRAY,
+    'ytick.color': DARK_GRAY,
+    'axes.axisbelow': True,
+    'font.family': 'sans',
+    'font.weight': 'regular',
+    'font.size': BASE_FONTSIZE,
+    'grid.linestyle': '-',
+    'lines.solid_capstyle': 'round',
+    'axes.facecolor': 'white',
+    'axes.edgecolor': LIGHT_GRAY,
+    'axes.linewidth': 1,
+    'grid.color': LIGHT_GRAY,
+    'lines.linewidth': 1.0,
+    'axes.linewidth': 1.0,
+}
+
 
 def zoom_y_min(data, outliers, start_from=0):
     array = numpy.array(data)
@@ -152,25 +179,22 @@ def compute_grid_offsets(d_min, d_max, num):
     return [d_min + i * freq for i in xrange(num + 1)]
 
 
-def style_axis(ax, major_xticks, minor_xticks, major_yticks, minor_yticks, tick_fontsize):
-    ax.set_xticks(major_xticks)
-    ax.set_xticks(minor_xticks, minor=True)
-    ax.set_yticks(major_yticks)
-    ax.set_yticks(minor_yticks, minor=True)
-
-    x_ax = ax.get_xaxis()
-    y_ax = ax.get_yaxis()
-
-    x_ax.set_ticks_position('none')
-    y_ax.set_ticks_position('none')
-    x_ax.set_tick_params(labelsize=tick_fontsize, zorder=ZORDER_GRID)
-    y_ax.set_tick_params(labelsize=tick_fontsize, zorder=ZORDER_GRID)
-
+def style_axis(axis, major_xticks, minor_xticks, major_yticks, minor_yticks, tick_fontsize):
+    axis.set_xticks(major_xticks)
+    axis.set_xticks(minor_xticks, minor=True)
+    axis.set_yticks(major_yticks)
+    axis.set_yticks(minor_yticks, minor=True)
+    # Style ticks.
+    x_axis = axis.get_xaxis()
+    y_axis = axis.get_yaxis()
+    x_axis.set_ticks_position('none')
+    y_axis.set_ticks_position('none')
+    x_axis.set_tick_params(labelsize=tick_fontsize, zorder=ZORDER_GRID)
+    y_axis.set_tick_params(labelsize=tick_fontsize, zorder=ZORDER_GRID)
     # Grid should be drawn below all other splines.
-    ax.grid(which='minor', alpha=0.4, zorder=ZORDER_GRID)
-    ax.grid(which='major', alpha=0.8, zorder=ZORDER_GRID)
-
+    axis.grid(which='minor', alpha=0.4, zorder=ZORDER_GRID)
+    axis.grid(which='major', alpha=0.8, zorder=ZORDER_GRID)
+    # Remove hard outer frame.
     for i in ['right', 'left', 'top', 'bottom']:
-        ax.spines[i].set_visible(False)
-
-    ax.frameon = False
+        axis.spines[i].set_visible(False)
+    axis.frameon = False


### PR DESCRIPTION
Fixes #318 

Needs squashing.

For now, you don't need to test the `plot_outliers_by_threshold` script -- this is not used in `warmup_stats` and we have not used the script in a while. It may be worth testing `plot_krun_results` on OpenBSD, just to be sure.

### Test cases

10 pages from b3 v0.7:

  * With Seaborn:  [with-seaborn.pdf](https://github.com/softdevteam/warmup_experiment/files/858259/with-seaborn.pdf)
  * Without Seaborn: [rm-seaborn.pdf](https://github.com/softdevteam/warmup_experiment/files/858293/rm-seaborn.pdf)

Da Capo:

  * Plots generated by `warmup_stats` script: [with_warmup_script.pdf](https://github.com/softdevteam/warmup_experiment/files/858294/with_warmup_script.pdf)
