### PR TITLE
Clamp off by one and index fix

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -682,9 +682,9 @@ class ProcessExecChart(object):
                                         + int(one_pc * 2.0)))
             # Clamp the extent of the inset.
             if inset_xlimit[1] < INSET_MIN_ITERS:
-                inset_xlimit = (0, min(INSET_MIN_ITERS, self.x_bounds[1] - self.x_bounds[0]))
+                inset_xlimit = (0, min(INSET_MIN_ITERS, self.x_bounds[1] - self.x_bounds[0] - 1))
             elif inset_xlimit[1] > INSET_MAX_ITERS:
-                inset_xlimit = (0, min(INSET_MAX_ITERS, self.x_bounds[1] - self.x_bounds[0]))
+                inset_xlimit = (0, min(INSET_MAX_ITERS, self.x_bounds[1] - self.x_bounds[0] - 1))
             inset.set_xlim(inset_xlimit[0], inset_xlimit[1], auto=False)
             # Plot a subset of the data on the inset.
             start, end = self.x_bounds[0] + inset_xlimit[0], self.x_bounds[0] + inset_xlimit[1] + 1

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -282,7 +282,7 @@ def main(is_interactive, data_dcts, plot_titles, window_size, outfile,
                     else:
                         if data == page:  # Stops repeated printing of warning.
                             print("WARNING: requested pexec crashed: "
-                                  "%s, %s, %s, %s" % (mc, bmark, vm, index + 1))
+                                  "%s, %s, %s, %s" % (mc, bmark, vm, i))
                 return ret
 
             wct_page = only_uncrashed(page)


### PR DESCRIPTION
The crash we were discussing on MM is tiggered by the code that `clamps the extent of the inset`. I think this code makes a data-set one sample too big.

I don't  fully understand that logic, so please check carefully. My brain hurts.

Good news is, once this is applied, it does see the crashed pexec:
```
WARNING: requested pexec crashed: Linux$_\mathrm{E3-1240v5}$, N-Body, C, 3
```

But the index should be 0, not 3. Fixed that too.