### PR TITLE
Improve crashing extbench

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -1370,7 +1370,7 @@ if __name__ == '__main__':
                         iter_lens = len(pexec)
                         raise StopIteration()  # to break out of all loops at once
         else:
-            print('couldn't find a non-crashing pexec')
+            print('could not find a non-crashing pexec')
             sys.exit(1)
     except StopIteration:
         pass  # good, we found some non-crash data

--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -66,8 +66,10 @@ def main():
                         "%s -jar %s %s -n %s" % (jvm_cmd, JAR, benchmark,
                                                  ITERATIONS + 1), platform, failure_fatal=False)
                     if rc != 0:
-                        sys.stdout.write(stdout + "\n")
-                        sys.stdout.flush()
+                        sys.stderr.write("\nWARNING: process exec crashed\n")
+                        sys.stderr.write("stdout:\n")
+                        sys.stderr.write(stdout + "\n")
+                        sys.stderr.write("\nstderr:\n")
                         sys.stderr.write(stderr + "\n")
                         sys.stderr.flush()
                         continue

--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -72,6 +72,7 @@ def main():
                         sys.stderr.write("\nstderr:\n")
                         sys.stderr.write(stderr + "\n")
                         sys.stderr.flush()
+                        writer.writerow([process, benchmark, "crash"])
                         continue
                     output = []
                     for line in stderr.splitlines():

--- a/warmup/krun_results.py
+++ b/warmup/krun_results.py
@@ -39,10 +39,15 @@ def csv_to_krun_json(in_files, language, vm, uname):
             data_dictionary['audit']['uname'] = uname
             reader = csv.reader(fd)
             header = reader.next()  # Skip first row, which contains column names.
+            expect_idx = [0]  # check we get in-order indicies, first always 0
             for row in reader:
                 # First cell contains process execution number.
+                assert int(row[0]) in expect_idx
                 bench = row[1]
-                data = [float(datum) for datum in row[2:]]
+                if row[2] == "crash":
+                    data = []
+                else:
+                    data = [float(datum) for datum in row[2:]]
                 key = '%s:%s:default-%s' % (bench, vm, language)
                 if key not in data_dictionary['wallclock_times']:
                     data_dictionary['wallclock_times'][key] = list()
@@ -53,6 +58,7 @@ def csv_to_krun_json(in_files, language, vm, uname):
                 data_dictionary['core_cycle_counts'][key].append(None)
                 data_dictionary['aperf_counts'][key].append(None)
                 data_dictionary['mperf_counts'][key].append(None)
+                expect_idx = [0, int(row[0]) + 1]  # expect the next index, or a 0
         new_filename = os.path.splitext(filename)[0] + '.json.bz2'
         write_krun_results_file(data_dictionary, new_filename)
         return header, new_filename


### PR DESCRIPTION
DONT MERGE YET.

This makes the dacapo runner more resilient to crashes and ensures that the crash is indicated in the Krun results file once converted.

Testing blocked on #352.

Also I suppose octane needs the same treatment.