### PR TITLE
Classification used to determine which pexecs are flat.

### DIFF
--- a/warmup/summary_statistics.py
+++ b/warmup/summary_statistics.py
@@ -77,7 +77,7 @@ def collect_summary_statistics(data_dictionaries, delta, steady_state):
                 steady_state_means.append(steady_state_mean)
                 # Not all process execs have changepoints. However, all
                 # p_execs will have one or more segment mean.
-                if data_dictionaries[machine]['changepoints'][key][p_exec]:
+                if data_dictionaries[machine]['classifications'][key][p_exec] != 'flat':
                     steady_iter = data_dictionaries[machine]['changepoints'][key][p_exec][first_steady_segment - 1]
                     steady_iters.append(steady_iter + 1)
                     to_steady = 0.0


### PR DESCRIPTION
Now that we keep changepoints in the data, even where there are "equivalent" segments, we can no longer use the number of changepoints to tell whether a pexec is flat or not.

### Test cases

  * Before this PR: [master_bencher7_table.pdf](https://github.com/softdevteam/warmup_experiment/files/900629/master_bencher7_table.pdf)
  * After this PR: [bencher7_table.pdf](https://github.com/softdevteam/warmup_experiment/files/900631/bencher7_table.pdf)
