### PR TITLE
Fix plotting instrumentation data.

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -418,8 +418,7 @@ class ProcessExecChart(object):
                 self.cycles_data.append(numpy.array(cycles_data[core][x_bounds[0]:x_bounds[1]]))
         self.instr_data = list()
         if instr_data:
-            for chart_data in instr_data:
-                self.instr_data.append(numpy.array(chart_data.data))
+            self.instr_data = instr_data
         # Generate medians and Tukey interval, if necessary.
         self.medians = None
         self.tukey_interval = (None, None)
@@ -683,17 +682,17 @@ class ProcessExecChart(object):
         """Add any VM instrumentation data on another set of charts."""
         legend_texts = set()
         self.instr_axes = [None] * len(self.instr_data)
-        for index in xrange(len(self.instr_data)):
-            legend_texts.add(self.instr_data[index].legend_text)
-        for index in xrange(len(self.instr_data)):
+        for index, idata in enumerate(self.instr_data):
+            legend_texts.add(idata.legend_text)
+        for index, idata in enumerate(self.instr_data):
             self.instr_axes[index] = pyplot.subplot(self.inner_grid[self.row, 0],
                                                     sharex=self.wallclock_axis)
-            self.instr_axes[index].plot(self.iterations, self.instr_data[index],
-                        color=INSTR_COLOR, label=(self.instr_data[index].title),
+            self.instr_axes[index].plot(self.iterations, idata.data,
+                        color=INSTR_COLOR, label=idata.title,
                       linewidth=LINE_WIDTH, zorder=ZORDER_DATA)
             self.instr_axes[index].set_ylim(self.instr_y_ranges[index])
             self.style_axis(self.instr_axes[index], self.instr_y_ranges[index],
-                            None, self.instr_data[index].title, color=INSTR_COLOR)
+                            None, idata.title, color=INSTR_COLOR)
             if index == 0:
                 # Add all items to page legend (only once).
                 handles, labels = self.instr_axes[index].get_legend_handles_labels()

--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -1484,13 +1484,16 @@ if __name__ == '__main__':
     if options.core_cycles and options.wallclock:
         fatal_error('Cannot use --core-cycles AND --wallclock-only.')
 
-    if options.core_cycles and not options.wallclock:
-        try:
-            cycles_str = options.core_cycles.split(',')
-            core_cycles = [int(cycle) for cycle in cycles_str]
-        except ValueError:
-            fatal_error('invalid --core-cycles argument')
-        print 'Plotting cycle counts for core(s): %s' % ','.join([str(core) for core in core_cycles])
+    if options.core_cycles is not None and not options.wallclock:
+        if options.core_cycles.strip() == "":
+            core_cycles = list()
+        else:
+            try:
+                cycles_str = options.core_cycles.split(',')
+                core_cycles = [int(cycle) for cycle in cycles_str]
+            except ValueError:
+                fatal_error('invalid --core-cycles argument')
+            print 'Plotting cycle counts for core(s): %s' % ','.join([str(core) for core in core_cycles])
     else:
         core_cycles = None
 


### PR DESCRIPTION
I think this fixes #386. We were throwing away everything but the samples from the instr data, then later expecting it to be there. This brings it back. Also it seems that there is no need to convert to a numpy array.

Is the legend still used? There's a command line option `--no-legend`, but I don't recall seeing a legend for some time!

Thanks