### PR TITLE
Fix georges

### DIFF
--- a/bin/table_georges_comparison
+++ b/bin/table_georges_comparison
@@ -26,6 +26,9 @@ _START_TABLE = lambda format_, headings: """
 \\midrule
 """ % (format_, headings)
 
+_NUMBERS = {0:'zero', 1:'one', 2:'two', 3:'three', 4:'four', 5:'five',
+            6:'six', 7:'seven', 8:'eight', 9:'nine'}
+
 
 def _start_table(format_, headings):
     """Unlike the start_table() function in warmup.latex, this one does not
@@ -85,7 +88,7 @@ def compute_comparison(in_files, threshold):
     return counts
 
 
-def write_tables(counts, tex_filename, with_preamble=False):
+def write_table(counts, tex_filename, with_preamble=False):
     """Write out LaTeX table."""
 
     print('Writing data to: %s.' % options.latex_file)
@@ -116,6 +119,56 @@ def write_tables(counts, tex_filename, with_preamble=False):
             fp.write(end_document())
 
 
+def _reformat(word):
+    """Reformat word as a LaTeX macro name.
+    Removes spaces and underscores. Translates numbers to words. Lower cases.
+    """
+
+    for number in _NUMBERS:
+        word = word.replace(str(number), _NUMBERS[number])
+    word = str(word).translate(None, ' _')
+    return word.lower()
+
+
+def write_macros(counts, tex_filename):
+    """Write out macros that summarise the information in the table."""
+
+    # Sum data over all machines.
+    totals = {'warmup': 0, 'slowdown': 0, 'flat': 0, 'no steady state': 0,
+              'total warmup': 0, 'total flat': 0, 'total slowdown': 0,
+              'total no steady state': 0}
+    for machine in counts:
+        for category in ('flat', 'warmup', 'slowdown', 'no steady state'):
+            totals[category] += counts[machine][category]
+            totals['total ' + category] += counts[machine]['total ' + category]
+    print('Writing data to %s.' % tex_filename)
+    with open(tex_filename, 'w') as fd:
+        fd.write('%%%\n')
+        fd.write('%%% Number of benchmarks on that Georges et al. found to reach a state state.\n')
+        fd.write('%%%\n')
+        for machine in counts:
+            mc_name = _reformat(machine)
+            for category in ('flat', 'warmup', 'slowdown', 'no steady state'):
+                fd.write('\\newcommand{\\%s}{%d}\n' %
+                         (_reformat('georges' + mc_name + category), counts[machine][category]))
+        fd.write('%%%\n')
+        fd.write('%%% Percentage of benchmarks on that Georges et al. found to reach a state state.\n')
+        fd.write('%%%\n')
+        for machine in counts:
+            mc_name = _reformat(machine)
+            for category in ('flat', 'warmup', 'slowdown', 'no steady state'):
+                fd.write('\\newcommand{\\%s}{%.1f}\n' %
+                         (_reformat('georges' + mc_name + category + 'percent'),
+                          float(counts[machine][category]) / float(counts[machine]['total ' + category]) * 100.0))
+        fd.write('%%%\n')
+        fd.write('%%% Percentage of benchmarks over all machines that Georges et al. found to reach a state state.\n')
+        fd.write('%%%\n')
+        for category in ('flat', 'warmup', 'slowdown', 'no steady state'):
+            fd.write('\\newcommand{\\%s}{%.1f}\n' %
+                     (_reformat('georges' + category + 'percent'),
+                      float(totals[category]) / float(totals['total ' + category]) * 100.0))
+
+
 def create_cli_parser():
     """Create a parser to deal with command line switches."""
 
@@ -141,6 +194,8 @@ def create_cli_parser():
 if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
+    base_filename, extention = os.path.splitext(options.latex_file)
     print('Using CoV threshold %.3f.' % options.threshold)
     counts = compute_comparison(options.json_files[0], options.threshold)
-    write_tables(counts, options.latex_file, options.with_preamble)
+    write_table(counts, options.latex_file, options.with_preamble)
+    write_macros(counts, base_filename + '_macros' + extention)

--- a/bin/table_georges_comparison
+++ b/bin/table_georges_comparison
@@ -66,14 +66,20 @@ def compute_comparison(in_files, threshold):
             else:
                 bench, vm, variant = key.split(':')
                 n_pexecs = len(data_dictionaries[machine]['wallclock_times'][key])
+                # In the Georges et al. (2007) paper, measurements are defined
+                # as x_i,j where i is the ith invocation of the VM, and j is
+                # a benchmark iteration. In this code pexec is "i", and iteration
+                # "j". The "k" iterations that we might to retain (i.e. the
+                # minimum length of a steady state) is called steady.
                 for pexec in xrange(n_pexecs):
-                    stop = len(data_dictionaries[machine]['wallclock_times'][key][pexec]) - steady
                     classification = data_dictionaries[machine]['classifications'][key][pexec]
                     counts[machine]['total ' + classification] += 1
-                    for iteration in xrange(len(data_dictionaries[machine]['wallclock_times'][key][pexec])):
-                        if iteration >= stop:
-                            break  # We expected to reach a steady state by now.
-                        if _cov(data_dictionaries[machine]['wallclock_times'][key][pexec][iteration:]) < threshold:
+                    iter_length = len(data_dictionaries[machine]['wallclock_times'][key][pexec])
+                    for iteration in xrange(steady, iter_length):
+                        start = iteration - steady
+                        end = iteration + 1
+                        this_cov = _cov(data_dictionaries[machine]['wallclock_times'][key][pexec][start:end])
+                        if this_cov < threshold:
                             counts[machine][classification] += 1
                             break
     return counts
@@ -102,7 +108,7 @@ def write_tables(counts, tex_filename, with_preamble=False):
             row = [STYLE_SYMBOLS[style]] + \
                       ['%.2f\\%%' % (float(counts[machine][style]) /
                                      float(counts[machine]['total ' + style]) * 100.0)
-                       for machine in machines]
+                       for machine in sorted(machines)]
             fp.write('%s\\\\ \n' % '&'.join(row))
         fp.write(end_table())
         if with_preamble:


### PR DESCRIPTION
**Needs squashing**

This PR is a simplified version of the code in the `georges_more_detailed` branch. It contributes the following:

  * Fixes the core algorithm that implemented the method in Georges et al.
  * Fixes a bug in the tables (due to not always sorting the rows by machine name)
  * Adds a feature to write out summary macros of the data in the tables

Unlike the other branch, this one does not include the "more detailed" tables with per-benchmark data.

### Testing

Since the code in the other branch is buggy, the output of this script now needs to be tested against the data it collects. For the v0.8 data, these are the raw counts:

```python
{u'bencher5': {'flat': 357, 'total no steady state': 120, 'total warmup': 666, 'warmup': 666, 'total flat': 364, 'no steady state': 100, 'total slowdown': 230, 'slowdown': 229}, 

u'bencher7': {'flat': 289, 'total no steady state': 133, 'total warmup': 711, 'warmup': 711, 'total flat': 289, 'no steady state': 102, 'total slowdown': 247, 'slowdown': 247}, 

u'bencher6': {'flat': 303, 'total no steady state': 25, 'total warmup': 469, 'warmup': 465, 'total flat': 306, 'no steady state': 15, 'total slowdown': 100, 'slowdown': 98}}
``` 

This is the table: [new_pr.pdf](https://github.com/softdevteam/warmup_experiment/files/930521/new_pr.pdf)

And these are the summary macros:

```latex
%%%
%%% Number of benchmarks on that Georges et al. found to reach a state state.
%%%
\newcommand{\georgesbencherfiveflat}{357}
\newcommand{\georgesbencherfivewarmup}{666}
\newcommand{\georgesbencherfiveslowdown}{229}
\newcommand{\georgesbencherfivenosteadystate}{100}
\newcommand{\georgesbenchersevenflat}{289}
\newcommand{\georgesbenchersevenwarmup}{711}
\newcommand{\georgesbenchersevenslowdown}{247}
\newcommand{\georgesbenchersevennosteadystate}{102}
\newcommand{\georgesbenchersixflat}{303}
\newcommand{\georgesbenchersixwarmup}{465}
\newcommand{\georgesbenchersixslowdown}{98}
\newcommand{\georgesbenchersixnosteadystate}{15}
%%%
%%% Percentage of benchmarks on that Georges et al. found to reach a state state.
%%%
\newcommand{\georgesbencherfiveflatpercent}{98.1}
\newcommand{\georgesbencherfivewarmuppercent}{100.0}
\newcommand{\georgesbencherfiveslowdownpercent}{99.6}
\newcommand{\georgesbencherfivenosteadystatepercent}{83.3}
\newcommand{\georgesbenchersevenflatpercent}{100.0}
\newcommand{\georgesbenchersevenwarmuppercent}{100.0}
\newcommand{\georgesbenchersevenslowdownpercent}{100.0}
\newcommand{\georgesbenchersevennosteadystatepercent}{76.7}
\newcommand{\georgesbenchersixflatpercent}{99.0}
\newcommand{\georgesbenchersixwarmuppercent}{99.1}
\newcommand{\georgesbenchersixslowdownpercent}{98.0}
\newcommand{\georgesbenchersixnosteadystatepercent}{60.0}
%%%
%%% Percentage of benchmarks over all machines that Georges et al. found to reach a state state.
%%%
\newcommand{\georgesflatpercent}{99.0}
\newcommand{\georgeswarmuppercent}{99.8}
\newcommand{\georgesslowdownpercent}{99.5}
\newcommand{\georgesnosteadystatepercent}{78.1}
```
