### PR TITLE
Add mc totals

### DIFF
--- a/bin/create_summary_macros
+++ b/bin/create_summary_macros
@@ -5,13 +5,10 @@ Must be run after mark_changepoints_in_json.
 
 import argparse
 import copy
-import locale
 import math
 import os
 import os.path
 import sys
-
-locale.setlocale(locale.LC_ALL, '')
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import read_krun_results_file
@@ -200,7 +197,7 @@ def write_latex_summary(summary, tex_file):
         fd.write('%%% Total executions and iterations.\n')
         fd.write('%%%\n')
         fd.write('\\newcommand{\\totalpexecs}{%d}\n' % summary['total_pexecs'])
-        fd.write('\\newcommand{\\totaliterations}{%s}\n' % locale.format('%d', summary['total_iterations'], grouping=True))
+        fd.write('\\newcommand{\\totaliterations}{%d}\n' % summary['total_iterations'])
         for machine in sorted(summary['machine_pexecs']):
             fd.write('\\newcommand{\\%s}{%s}\n' %
                      (_reformat(machine) + 'totalpexecs', summary['machine_pexecs'][machine]))

--- a/bin/create_summary_macros
+++ b/bin/create_summary_macros
@@ -33,6 +33,7 @@ def main(data, latex_file):
                'total_consistent_percentages': copy.deepcopy(BLANK_CONSISTENT),
                # Per-machine summaries.
                'machines': dict(), 'machine_percentages': dict(),
+               'machine_pexecs': dict(), 'machine_iterations': dict(),
                'machine_consistent': dict(),
                'machine_consistent_percentages': dict(),
                'machine_vm_bench_classes': dict(),
@@ -43,6 +44,8 @@ def main(data, latex_file):
                'vm_bench_consistent_percentages': dict(),}
     for machine in data:
         summary['machines'][machine] = copy.deepcopy(BLANK_CLASSES)
+        summary['machine_pexecs'][machine] = 0
+        summary['machine_iterations'][machine] = 0
         summary['machine_percentages'][machine] = copy.deepcopy(BLANK_CLASSES)
         summary['machine_consistent'][machine] = copy.deepcopy(BLANK_CONSISTENT)
         summary['machine_consistent_percentages'][machine] = copy.deepcopy(BLANK_CONSISTENT)
@@ -61,6 +64,8 @@ def main(data, latex_file):
                       (key, machine))
             else:
                 for p_exec in data_dicts[machine]['wallclock_times'][key]:
+                    summary['machine_pexecs'][machine] += 1
+                    summary['machine_iterations'][machine] += len(p_exec)
                     summary['total_pexecs'] += 1
                     summary['total_iterations'] += len(p_exec)
                 vm_bench = ' '.join((vm, bench))
@@ -196,6 +201,12 @@ def write_latex_summary(summary, tex_file):
         fd.write('%%%\n')
         fd.write('\\newcommand{\\totalpexecs}{%d}\n' % summary['total_pexecs'])
         fd.write('\\newcommand{\\totaliterations}{%s}\n' % locale.format('%d', summary['total_iterations'], grouping=True))
+        for machine in sorted(summary['machine_pexecs']):
+            fd.write('\\newcommand{\\%s}{%s}\n' %
+                     (_reformat(machine) + 'totalpexecs', summary['machine_pexecs'][machine]))
+        for machine in sorted(summary['machine_iterations']):
+            fd.write('\\newcommand{\\%s}{%s}\n' %
+                     (_reformat(machine) + 'totaliterations', summary['machine_iterations'][machine]))
         fd.write('%%%\n')
         fd.write('%%% Total classifications over all executions.\n')
         fd.write('%%%\n')


### PR DESCRIPTION
This PR adds a couple of new macros that we need, it also removes the "locale" formatting, which we can do in LaTeX. New macros are:

```latex
\newcommand{\bencherfivetotalpexecs}{1380}
\newcommand{\benchersixtotalpexecs}{900}
\newcommand{\bencherseventotalpexecs}{1380}
\newcommand{\bencherfivetotaliterations}{2760000}
\newcommand{\benchersixtotaliterations}{1800000}
\newcommand{\bencherseventotaliterations}{2760000}
```