### PR TITLE
Check the SSH identity as a pre-execution command.

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -209,4 +209,4 @@ POST_EXECUTION_CMDS.append("%s %s 'test ! -e %s/%s.stop'" %
 #   2) You have accepted the remote server's host key (in interactive mode).
 #   3) Remote host exists and is up!
 CHECK_SSH_CMD = "%s %s true" % (SSH_BATCH, REMOTE_LOGIN)
-run_shell_cmd(CHECK_SSH_CMD)
+PRE_EXECUTION_CMDS.insert(0, CHECK_SSH_CMD)


### PR DESCRIPTION
We insert at the beginning to ensure the command happens prior to any network downing.

When all is well:
```
[2017-05-04 11:39:24: DEBUG] execute shell cmd: ssh -o 'BatchMode yes' -i id_rsa vext01@bencher2.soft-dev.org true
[2017-05-04 11:39:25: DEBUG] execute shell cmd: sudo systemctl stop cron
[2017-05-04 11:39:25: DEBUG] execute shell cmd: sudo systemctl stop atd
[2017-05-04 11:39:25: DEBUG] execute shell cmd: sudo systemctl stop postfix
```

When something is wrong:
```
[2017-05-04 11:40:28: DEBUG] execute shell cmd: ssh -o 'BatchMode yes' -i id_rsa vext01@bencher2.soft-dev.org true
[2017-05-04 11:40:28: ERROR] Command failed: 'ssh -o 'BatchMode yes' -i id_rsa vext01@bencher2.soft-dev.org true'
stdout:

stderr:
Warning: Identity file id_rsa not accessible: No such file or directory.
Permission denied (publickey,password).


[2017-05-04 11:40:28: DEBUG] execute shell cmd: sudo systemctl start cron || true
[2017-05-04 11:40:28: DEBUG] execute shell cmd: sudo systemctl start atd || true
```

Note the post-exec commands running after the failure. We will get an email in the error case.

OK?