### PR TITLE
Use wget for downloads by default.

### DIFF
--- a/build_stats.sh
+++ b/build_stats.sh
@@ -28,7 +28,7 @@ export LD_LIBRARY_PATH=${R_INST_DIR}/lib/R/lib:${LD_LIBRARY_PATH}
 
 # Install R changepoint package.
 echo "install.packages('devtools', lib='${R_INST_DIR}/lib/R/library', repos='http://cran.us.r-project.org')" | R_LIBS_USER=${R_INST_DIR}/lib/R/library/ ${R_INST_DIR}/bin/R --no-save
-echo "devtools::install_github('rkillick/changepoint')" | R_LIBS_USER=${R_INST_DIR}/lib/R/library/ ${R_INST_DIR}/bin/R --no-save
+echo "options(download.file.method = \"wget\"); devtools::install_github('rkillick/changepoint')" | R_LIBS_USER=${R_INST_DIR}/lib/R/library/ ${R_INST_DIR}/bin/R --no-save
 
 # Install rpy2 Python package.
 pip install -t ${PIP_TARGET_DIR} rpy2


### PR DESCRIPTION
 Fixes a bug in some Debian systems (e.g. bencher3) already documented in INSTALL.md.