### PR TITLE
Use TruffleRuby as the VM's name.

### DIFF
--- a/bin/plot_krun_results
+++ b/bin/plot_krun_results
@@ -88,6 +88,10 @@ BENCHMARKS = {
     'nbody':            'N-Body',
 }
 
+VMS = {
+    'JRubyTruffle':     'TruffleRuby',
+}
+
 GRID_MINOR_X_DIVS = 20
 GRID_MAJOR_X_DIVS = 10
 
@@ -1180,6 +1184,9 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                     benchmark_name = BENCHMARKS[benchmark_name]
                 else:
                     benchmark_name = benchmark_name.title()
+                vm_name = key.split(':')[1]
+                if vm_name in VMS:
+                    vm_name = VMS[vm_name]
 
                 # Add one title for each process execution
                 try:
@@ -1195,7 +1202,7 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                             classification = ''
                         title = '%s, %s, %s, Proc. exec. #%d%s' % \
                                 (benchmark_name,
-                                 key.split(':')[1],
+                                 vm_name,
                                  machine_name,
                                  p_exec + 1,
                                  classification)
@@ -1266,6 +1273,9 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                         benchmark_name = BENCHMARKS[benchmark_name]
                     else:
                         benchmark_name = benchmark_name.title()
+                    vm_name = key.split(':')[1]
+                    if vm_name in VMS:
+                        vm_name = VMS[vm_name]
                     for p_exec in requested_data[key][machine]:
                         if p_exec >= len(data['wallclock_times'][key]):
                             fatal_error('You requested that process execution %g '
@@ -1301,7 +1311,7 @@ def get_data_dictionaries(json_files, benchmarks=[], wallclock_only=False,
                             classification = ''
                         title = '%s, %s, %s, Proc. exec. #%d%s' % \
                                 (benchmark_name,
-                                 key.split(':')[1],
+                                 vm_name,
                                  machine_name,
                                  p_exec + 1,
                                  classification)

--- a/bin/table_classification_summaries_main
+++ b/bin/table_classification_summaries_main
@@ -55,7 +55,7 @@ from warmup.summary_statistics import collect_summary_statistics, convert_to_lat
 
 
 VM_NAMES_MAP = {
-    'JRubyTruffle': 'JRuby+Truffle',
+    'JRubyTruffle': 'TruffleRuby',
     'Hotspot': 'HotSpot'
 }
 

--- a/build.sh
+++ b/build.sh
@@ -577,7 +577,7 @@ TRUFFLERUBY_V=graal-vm-0.22
 TRUFFLERUBY_BUILDPACK_DIR=${wrkdir}/truffleruby-buildpack
 TRUFFLERUBY_BUILDPACK_TARBALL=truffleruby-buildpack-${TRUFFLERUBY_V}-20170502.tgz
 build_truffleruby() {
-    echo "\n===> Download and build truffle+jruby\n"
+    echo "\n===> Download and build TruffleRuby\n"
 
     # maven caches dependencies, we dont ever want to pick those up, only
     # what's in the jruby build pack.


### PR DESCRIPTION
This changed underneath us a couple of times and we didn't consistently update
it.