### PR TITLE
Truncated iteration stats

### DIFF
--- a/bin/plot_truncated_iterations
+++ b/bin/plot_truncated_iterations
@@ -51,7 +51,6 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import parse_krun_file_with_changepoints
-from warmup.latex import end_document, preamble
 from warmup.plotting import add_margin_to_axes, compute_grid_offsets, style_axis, STYLE_DICT
 
 # Set matplotlib styles, similar to Seaborn 'whitegrid'.
@@ -105,60 +104,6 @@ def summarise_truncated(data_dir):
     return summary
 
 
-def start_table(format_, headings):
-    return """
-{
-\\begin{longtable}{%s}
-\\toprule
-%s \\\\
-\\midrule
-""" % (format_, headings)
-
-
-def end_table():
-    return """
-\\bottomrule
-\\end{longtable}
-}
-"""
-
-
-def write_table(summary, outfile, with_preamble=False):
-    """Write out a LaTeX table, with or without preamble."""
-
-    table_format = 'l' + ('r' * 6)
-    table_headings = '&'.join(['\\textbf{\\# Iterations}', '\\textbf{\\# Same}',
-                              '\\textbf{\\# Different}', '\\textbf{\\# Delta}',
-                              '\\textbf{\\% Same}', '\\textbf{\\% Different}',
-                              '\\textbf{\\% Delta}',])
-    total_original = float(summary[DEFAULT_ITERS]['same'] + summary[DEFAULT_ITERS]['different'])
-    with open(outfile, 'w') as fp:
-        if with_preamble:
-            fp.write(preamble('Truncated data results'))
-            fp.write('\\centering\n')
-        fp.write(start_table(table_format, table_headings))
-        for last_iter in sorted(summary, reverse=True):
-            total = float(summary[last_iter]['same'] + summary[last_iter]['different'])
-            assert total == total_original
-            if last_iter == DEFAULT_ITERS:
-                fp.write('%d & %d & %d & %s & %.2f & %.2f & %s \\\\' %
-                         (last_iter, summary[last_iter]['same'], summary[last_iter]['different'],
-                          'n/a', summary[last_iter]['same'] / total * 100.0,
-                          summary[last_iter]['different'] / total * 100.0, 'n/a'))
-            else:
-                pc_delta = (summary[last_iter + ITER_STEP]['same'] / total * 100.0) - \
-                             (summary[last_iter]['same'] / total * 100.0)
-                fp.write('%d & %d & %d & %d & %.2f & %.2f & %.2f\\\\' %
-                         (last_iter, summary[last_iter]['same'], summary[last_iter]['different'],
-                          summary[last_iter + ITER_STEP]['same'] - summary[last_iter]['same'],
-                          summary[last_iter]['same'] / total * 100.0,
-                          summary[last_iter]['different'] / total * 100.0, pc_delta))
-        fp.write(end_table())
-        if with_preamble:
-            fp.write(end_document())
-    print('Saved: %s' % outfile)
-
-
 def draw_plot(summary, outfile):
     """Plot 'same' data and write to PDF file."""
 
@@ -198,23 +143,14 @@ def create_cli_parser():
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('directory', action='store', default='.', type=str,
                         help='Directory containing truncated results files.')
-    parser.add_argument('--texfile', '-t', action='store', dest='latex_file',
-                        type=str, help='Name of the LaTeX file to write table to.',
-                        required=True)
     parser.add_argument('--pdffile', '-p', action='store', dest='plot_file',
                         type=str, help='Name of the PDF file to write plot to.',
                         required=True)
-    parser.add_argument('--with-preamble', action='store_true',
-                        dest='with_preamble', default=False,
-                        help='Write out a whole LaTeX article (not just the table).')
     return parser
 
 
 if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
-    if options.with_preamble:
-        print 'Writing out full document, with preamble.'
     summary = summarise_truncated(options.directory)
-    write_table(summary, options.latex_file, options.with_preamble)
     draw_plot(summary, options.plot_file)

--- a/bin/plot_truncated_iterations
+++ b/bin/plot_truncated_iterations
@@ -38,24 +38,53 @@
 # SOFTWARE.
 
 import argparse
-import copy
 import glob
+import json
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as pyplot
 from matplotlib.backends.backend_pdf import PdfPages
+import numpy
 import os
 import os.path
 import sys
 
+# We use a custom install of rpy2, relative to the top-level of the repo.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                'work', 'pylibs'))
+# R packages are stored relative to the top-level of the repo.
+os.environ['PATH'] = ':'.join([os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                               'work', 'R-inst', 'bin'), os.environ.get('PATH', '')])
+os.environ['LD_LIBRARY_PATH'] = ':'.join([os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                         'work', 'R-inst', 'lib', 'R', 'lib'), os.environ.get('LD_LIBRARY_PATH', '')])
+os.environ['R_LIBS_USER'] = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                         'work', 'R-inst', 'lib', 'R', 'library')
+
+import rpy2
+import rpy2.interactive.packages
+import rpy2.robjects
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from warmup.krun_results import parse_krun_file_with_changepoints
 from warmup.plotting import add_margin_to_axes, compute_grid_offsets, style_axis, STYLE_DICT
+from warmup.summary_statistics import collect_summary_statistics
 
 # Set matplotlib styles, similar to Seaborn 'whitegrid'.
 for style in STYLE_DICT:
     matplotlib.rcParams[style] = STYLE_DICT[style]
+
+ALPHA = 0.01  # Significance level.
+CATEGORIES = ['warmup', 'slowdown', 'flat', 'no steady state']
+MCI = rpy2.interactive.packages.importr('MultinomialCI')
+# List indices (used in favour of dictionary keys).
+CLASSIFICATIONS = 0  # Indices for top-level summary lists.
+STEADY_ITER = 1
+STEADY_STATE_TIME = 2
+INTERSECTION = 3
+LAST_ITERS = 4
+SAME = 0  # Indices for nested lists.
+DIFFERENT = 1
+
 
 # Default (PDF) font sizes
 TICK_FONTSIZE = 8
@@ -64,43 +93,192 @@ AXIS_FONTSIZE = 8
 GRID_MAJOR_X_DIVS = 10
 GRID_MAJOR_Y_DIVS = 10
 
-LINE_COLOUR = 'k'
-LINE_WIDTH = 1
+LINE_WIDTH = 0.4
+MARKER_SIZE = 1
 
 DEFAULT_ITERS = 2000  # Iterations in original data file.
 ITER_STEP = 10  # Truncated data files each differ by ITER_STEP iterations.
 
+DEFAULT_SUMMARY_FILE = 'truncated_summary.json'
+EXPORT_SIZE = [12, 5]
+
 pyplot.figure(tight_layout=True)
 
 
-def summarise_truncated(data_dir):
+def do_intervals_differ((x1, y1), (x2, y2)):
+    """Given two IQRs or CIs return True if they do NOT overlap."""
+
+    assert y1 >= x1 and y2 >= x2
+    return y1 < x2 or y2 < x1
+
+
+def do_mean_cis_differ(mean1, ci1, mean2, ci2):
+    """Given two means +/- CIs return True if they do NOT overlap."""
+
+    assert ci1 >= 0.0 and ci2 >= 0.0, 'Found negative confidence interval from bootstrapping.'
+    x1 = mean1 - ci1
+    y1 = mean1 + ci1
+    x2 = mean2 - ci2
+    y2 = mean2 + ci2
+    return do_intervals_differ((x1, y1), (x2, y2))
+
+
+def all_flat(classifications):
+    """Return True if all pexecs in a detailed classification dict are 'flat'."""
+
+    return (classifications['warmup'] == 0 and classifications['slowdown'] == 0
+            and classifications['no steady state'] == 0)
+
+
+def all_nss(classifications):
+    """Return True if all pexecs in a detailed classification dict are 'no steady state'."""
+
+    return (classifications['warmup'] == 0 and classifications['slowdown'] == 0 and
+            classifications['flat'] == 0)
+
+
+def any_nss(classifications):
+    """Return True if any pexec in a detailed classification dict is 'no steady state'."""
+
+    return classifications['no steady state'] > 0
+
+
+def summarise_truncated(data_dir, jsonfile):
     """Summarise classifications in truncated data that match the original."""
 
-    truncated_results = dict()
+    classifiers = dict()
     original_results = None
-    for filename in glob.glob(os.path.join(data_dir, '*_changepoints.json.bz2')):
+    truncated_summaries = dict()
+    n_files = len(glob.glob(os.path.join(data_dir, '*_changepoints.json.bz2')))
+    for index, filename in enumerate(glob.glob(os.path.join(data_dir, '*_changepoints.json.bz2'))):
         if 'truncated_' not in filename:  # Original results file.
-            print 'Loading original results.'
-            _, original_results = parse_krun_file_with_changepoints([filename])
-            truncated_results[2000] = copy.deepcopy(original_results)
+            print('Loading original results. File %d of %d' % (index + 1, n_files))
+            classifiers[DEFAULT_ITERS], original_results = parse_krun_file_with_changepoints([filename])
+            truncated_summaries[DEFAULT_ITERS] = collect_summary_statistics(original_results,
+                                                     classifiers[DEFAULT_ITERS]['delta'], classifiers[DEFAULT_ITERS]['steady'])
         else:
-            last_iter = filename.split('.')[0].split('_')[1]
-            print 'Loading last iter', last_iter, 'results file.'
-            _, truncated_results[int(last_iter)] = parse_krun_file_with_changepoints([filename])
+            last_iter = int(os.path.basename(filename).split('.')[0].split('_')[1])
+            print('Loading results file truncated to %d iterations. File %d of %d.' %  (last_iter, index + 1, n_files))
+            classifiers[last_iter], truncated_results = parse_krun_file_with_changepoints([filename])
+            truncated_summaries[last_iter] = collect_summary_statistics(truncated_results,
+                                                 classifiers[last_iter]['delta'], classifiers[last_iter]['steady'])
+            del truncated_results
     assert original_results is not None, 'No original results file.'
     assert len(original_results.keys()) == 1, 'Expected one machine per results file.'
     machine = original_results.keys()[0]
-    summary = dict()
-    for last_iter in truncated_results:
-        if last_iter not in summary:
-            summary[last_iter] = { 'same': 0, 'different': 0 }
-        for key in truncated_results[last_iter][machine]['classifications']:
-            for p_exec in xrange(len(truncated_results[last_iter][machine]['classifications'][key])):
-                if original_results[machine]['classifications'][key][p_exec] == \
-                      truncated_results[last_iter][machine]['classifications'][key][p_exec]:
-                    summary[last_iter]['same'] += 1
+    # Generate CIs for DEFAULT_ITER classification data.
+    class_cis = dict()
+    for key in original_results[machine]['classifications']:
+        if len(original_results[machine]['classifications'][key]) == 0:  # Skipped benchmark.
+            continue
+        class_counts = [original_results[machine]['classifications'][key].count(category) for category in CATEGORIES]
+        class_cis[key] = numpy.array(MCI.multinomialCI(rpy2.robjects.FloatVector(class_counts), ALPHA))
+    # Generate summary of results to be plotted.
+    last_iters = [iter_ for iter_ in sorted(truncated_summaries)]
+    summary = [[[0, 0] for _ in truncated_summaries], [[0, 0] for _ in truncated_summaries],
+               [[0, 0] for _ in truncated_summaries], [[0, 0] for _ in truncated_summaries],
+               last_iters]
+    for last_iter in last_iters:
+        index = last_iters.index(last_iter)
+        for key in original_results[machine]['classifications']:
+            if len(original_results[machine]['classifications'][key]) == 0:  # Skipped benchmark.
+                continue
+            intersection = True
+            bench, vm = key.split(':')[:-1]
+            # Classifications are available, whether or not summary statistics can be generated.
+            trunc_cat = [truncated_summaries[last_iter]['machines'][machine][vm][bench]['process_executons'][p]['classification'] \
+                         for p in xrange(len(truncated_summaries[last_iter]['machines'][machine][vm][bench]['process_executons']))]
+            trunc_counts = [trunc_cat.count(category) for category in CATEGORIES]
+            trunc_cis = numpy.array(MCI.multinomialCI(rpy2.robjects.FloatVector(trunc_counts), ALPHA))
+            for category in CATEGORIES:
+                cat_index = CATEGORIES.index(category)
+                if do_intervals_differ(class_cis[key][cat_index], trunc_cis[cat_index]):
+                    summary[CLASSIFICATIONS][index][DIFFERENT] += 1
+                    intersection = False
+                    break
+            else:
+                summary[CLASSIFICATIONS][index][SAME] += 1
+            sample = truncated_summaries[last_iter]['machines'][machine][vm][bench]
+            base_case = truncated_summaries[DEFAULT_ITERS]['machines'][machine][vm][bench]
+            # Case 1) All flat.
+            if (all_flat(sample['detailed_classification']) and all_flat(base_case['detailed_classification'])):
+                summary[STEADY_ITER][index][SAME] += 1
+                if base_case['steady_state_time_ci'] is None:
+                    summary[STEADY_STATE_TIME][index][DIFFERENT] += 1
+                    intersection = False
+                elif do_mean_cis_differ(base_case['steady_state_time'], base_case['steady_state_time_ci'],
+                                        sample['steady_state_time'], sample['steady_state_time_ci']):
+                    summary[STEADY_STATE_TIME][index][DIFFERENT] += 1
+                    intersection = False
                 else:
-                    summary[last_iter]['different'] += 1
+                    summary[STEADY_STATE_TIME][index][SAME] += 1
+                if intersection:
+                    summary[INTERSECTION][index][SAME] += 1
+                else:
+                    summary[INTERSECTION][index][DIFFERENT] += 1
+            # Case 2) One ALL FLAT, one not.
+            elif (all_flat(sample['detailed_classification']) or all_flat(base_case['detailed_classification'])):
+                if (any_nss(sample['detailed_classification']) or any_nss(base_case['detailed_classification'])):
+                    summary[STEADY_ITER][index][DIFFERENT] += 1
+                elif (all_flat(base_case['detailed_classification']) and
+                      do_intervals_differ((1.0, 1.0), sample['steady_state_iteration_iqr'])):
+                    summary[STEADY_ITER][index][DIFFERENT] += 1
+                elif (all_flat(sample['detailed_classification']) and
+                      do_intervals_differ((1.0, 1.0), base_case['steady_state_iteration_iqr'])):
+                    summary[STEADY_ITER][index][DIFFERENT] += 1
+                else:
+                    summary[STEADY_ITER][index][SAME] += 1
+                if (any_nss(sample['detailed_classification']) or any_nss(base_case['detailed_classification'])):
+                    summary[STEADY_STATE_TIME][index][DIFFERENT] += 1
+                elif do_mean_cis_differ(base_case['steady_state_time'], base_case['steady_state_time_ci'],
+                                        sample['steady_state_time'], sample['steady_state_time_ci']):
+                    summary[STEADY_STATE_TIME][index][DIFFERENT] += 1
+                else:
+                    summary[STEADY_STATE_TIME][index][SAME] += 1
+                summary[INTERSECTION][index][DIFFERENT] += 1
+            # Case 3) One contains an NSS (therefore no steady iter / perf available).
+            elif (any_nss(sample['detailed_classification']) or
+                  any_nss(base_case['detailed_classification'])):
+                if intersection:
+                    summary[INTERSECTION][index][SAME] += 1
+                else:
+                    summary[INTERSECTION][index][DIFFERENT] += 1
+            # Case 4) All three measures should be available in both the DEFAULT_ITER and last_iter cases.
+            else:
+                # If n_pexecs is small, and the steady_iters are all identical,
+                # we sometimes get odd IQRs like [7.000000000000001, 7.0], so
+                # deal with this as a special case to avoid triggering the assertion
+                # in do_intervals_differ.
+                if len(set(sample['steady_state_iteration_list'])) == 1:
+                    fake_iqr = (float(sample['steady_state_iteration_list'][0]), float(sample['steady_state_iteration_list'][0]))
+                    if do_intervals_differ(base_case['steady_state_iteration_iqr'], fake_iqr):
+                        summary[STEADY_ITER][index][DIFFERENT] += 1
+                        intersection = False
+                    else:
+                        summary[STEADY_ITER][index][SAME] += 1
+                elif do_intervals_differ(base_case['steady_state_iteration_iqr'],
+                                         sample['steady_state_iteration_iqr']):
+                    summary[STEADY_ITER][index][DIFFERENT] += 1
+                    intersection = False
+                else:
+                    summary[STEADY_ITER][index][SAME] += 1
+                if do_mean_cis_differ(base_case['steady_state_time'], base_case['steady_state_time_ci'],
+                                      sample['steady_state_time'], sample['steady_state_time_ci']):
+                    summary[STEADY_STATE_TIME][index][DIFFERENT] += 1
+                    intersection = False
+                else:
+                    summary[STEADY_STATE_TIME][index][SAME] += 1
+                # Store intersection of all characteristics.
+                if intersection:
+                    summary[INTERSECTION][index][SAME] += 1
+                else:
+                    summary[INTERSECTION][index][DIFFERENT] += 1
+            assert (summary[INTERSECTION][index][SAME] + summary[INTERSECTION][index][DIFFERENT]) == \
+                (summary[CLASSIFICATIONS][index][SAME] + summary[CLASSIFICATIONS][index][DIFFERENT]), \
+                'Wrong number of data for truncated iteration %d' % last_iter
+    with open(jsonfile, 'w') as fd:
+        json.dump(summary, fd)
+        print('Saved: %s' % jsonfile)
     return summary
 
 
@@ -110,24 +288,55 @@ def draw_plot(summary, outfile):
     pdf = PdfPages(outfile)
     fig, axis = pyplot.subplots()
     # Prepare data.
-    total = float(summary[DEFAULT_ITERS]['same'] + summary[DEFAULT_ITERS]['different'])
-    same_data = [summary[last_iter]['same'] / total * 100.0 for last_iter in sorted(summary.keys())]
-    min_x, max_x = 0, int(max(summary.keys()))
-    min_y, max_y = 0., max(same_data)
+    total_classifications = [float(summary[CLASSIFICATIONS][index][SAME] + summary[CLASSIFICATIONS][index][DIFFERENT]) \
+                             for index, _ in enumerate(sorted(summary[LAST_ITERS]))]
+    data_classifications = [float(summary[CLASSIFICATIONS][index][SAME]) / total_classifications[index] * 100.0 \
+                            for index, _ in enumerate(sorted(summary[LAST_ITERS]))]
+    total_iter = [float(summary[STEADY_ITER][index][SAME] + summary[STEADY_ITER][index][DIFFERENT]) \
+                  for index, _ in enumerate(sorted(summary[LAST_ITERS]))]
+    data_iter = [summary[STEADY_ITER][index][SAME] / total_iter[index] * 100.0 \
+                 for index, _ in enumerate(sorted(summary[LAST_ITERS]))]
+    total_time = [float(summary[STEADY_STATE_TIME][index][SAME] + summary[STEADY_STATE_TIME][index][DIFFERENT]) \
+                  for index, _ in enumerate(sorted(summary[LAST_ITERS]))]
+    data_time = [float(summary[STEADY_STATE_TIME][index][SAME]) / total_time[index] * 100.0 \
+                 for index, _ in enumerate(sorted(summary[LAST_ITERS]))]
+    total_intersection = [float(summary[INTERSECTION][index][SAME] + summary[INTERSECTION][index][DIFFERENT]) \
+                          for index, _ in enumerate(sorted(summary[LAST_ITERS]))]
+    raw_intersection = [float(summary[INTERSECTION][index][SAME]) / total_intersection[index] * 100.0 \
+                         for index, _ in enumerate(sorted(summary[INTERSECTION]))]
+    data_intersection = [min(raw_intersection[index], data_time[index], data_iter[index], data_classifications[index])
+                         for index, _ in enumerate(sorted(summary[LAST_ITERS]))]
+    for iteration in xrange(len(data_intersection)):
+        assert (data_intersection[iteration] <= data_classifications[iteration] and
+                data_intersection[iteration] <= data_iter[iteration] and
+                data_intersection[iteration] <= data_time[iteration])
     # Plot data.
-    axis.plot(sorted(summary.keys()), same_data, marker='.', markersize=2, linestyle='-', color=LINE_COLOUR)
+    xvals = sorted(summary[LAST_ITERS])
+    axis.plot(xvals, data_classifications, linewidth=LINE_WIDTH,
+               marker='.', markersize=MARKER_SIZE, linestyle='-', color='#d7191c', label='Classifications')
+    axis.plot(xvals, data_iter, marker='^', linewidth=LINE_WIDTH,
+              markersize=MARKER_SIZE, linestyle='-', color='#018571', label='Steady iteration (# or s)')
+    axis.plot(xvals, data_time, marker='.', linewidth=LINE_WIDTH,
+              markersize=MARKER_SIZE, linestyle='-', color='#7b3294', label='Steady performance (s)')
+    axis.plot(xvals, data_intersection, marker='.', linewidth=LINE_WIDTH,
+              markersize=MARKER_SIZE, linestyle='-', color='k', label='Overall')
     # Re-style the chart.
+    min_x, max_x = 0, int(max(xvals))
+    min_y, max_y = 0.0, 100.0  # Percentages.
     xlim = (min_x - (min_x % 100), max_x)
     major_xticks = range(xlim[0], xlim[1] + ITER_STEP * 20, ITER_STEP * 10)
     major_yticks = compute_grid_offsets(min_y - (min_y % 10), max_y, GRID_MAJOR_Y_DIVS)
     style_axis(axis, major_xticks, [], major_yticks, [], TICK_FONTSIZE)
     axis.set_xticklabels([str(label) for label in major_xticks], rotation=270)
-    axis.set_xlabel('#in-process iterations', fontsize=AXIS_FONTSIZE)
-    axis.set_ylabel('% of process executions with the same classification as n=2000',
-                    fontsize=AXIS_FONTSIZE)
+    axis.set_xlabel('In-process iterations', fontsize=AXIS_FONTSIZE)
+    axis.set_ylabel('%% similarity to n=%d' % max_x, fontsize=AXIS_FONTSIZE)
     axis.set_xlim(xlim)
     add_margin_to_axes(axis, x=0.02, y=0.02)
+    # Add a legend.
+    handles, labels = axis.get_legend_handles_labels()
+    pyplot.legend(loc='upper center', ncol=4, bbox_to_anchor=(0.5, 1.1), fontsize=AXIS_FONTSIZE)
     # Save figure.
+    fig.set_size_inches(*EXPORT_SIZE)
     pdf.savefig(fig, dpi=fig.dpi, orientation='portrait', bbox_inches='tight')
     pdf.close()
     print('Saved: %s' % outfile)
@@ -141,16 +350,28 @@ def create_cli_parser():
                     '\n\nExample usage:\n\n' +
                     '\t$ python %s -o summary.tex results.json.bz2') % script)
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument('directory', action='store', default='.', type=str,
-                        help='Directory containing truncated results files.')
-    parser.add_argument('--pdffile', '-p', action='store', dest='plot_file',
+    parser.add_argument('-o', '--outfile', action='store', dest='outfile',
                         type=str, help='Name of the PDF file to write plot to.',
                         required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-s', '--summary', action='store', default=None,
+                       type=str, help=('Read summary data from JSON file rather than '
+                                       'generating from a directory of truncated results.'))
+    group.add_argument('-d', '--directory', action='store',  type=str, default=None,
+                       help='Directory containing truncated results files.')
     return parser
 
 
 if __name__ == '__main__':
     parser = create_cli_parser()
     options = parser.parse_args()
-    summary = summarise_truncated(options.directory)
-    draw_plot(summary, options.plot_file)
+    if options.summary is None:
+        summary = summarise_truncated(options.directory, DEFAULT_SUMMARY_FILE)
+    else:
+        summary = None
+        with open(options.summary, 'r') as fd:
+            summary = json.load(fd)
+        if summary is None:
+            print('Could not open %s.' % options.summary)
+            sys.exit(1)
+    draw_plot(summary, options.outfile)

--- a/warmup/plotting.py
+++ b/warmup/plotting.py
@@ -73,6 +73,9 @@ STYLE_DICT = {
     'grid.color': LIGHT_GRAY,
     'lines.linewidth': 1.0,
     'axes.linewidth': 1.0,
+    # Ensure type 3 fonts are not used
+    'pdf.fonttype': 42,
+    'ps.fonttype': 42,
 }
 
 


### PR DESCRIPTION
**NEEDS SQUASHING**

Latest PDF from bencher7 data: [b8_fixed.pdf](https://github.com/softdevteam/warmup_experiment/files/1199924/b8_fixed.pdf)

The logic for collecting stats for each truncated iterations JSON file are quite complicated. This is partly because the stats available for each <VM, benchmark> pair differ depending on the classification of the <VM, benchmark> (as per the tables). In particular:

  * If all pexecs are flat we DO NOT have data for steady iter (#, s)
  * If all pexecs are NSS we have no summary data
  * If the <VM, benchmark> is inconsistent and contains an NSS we have no summary data

Please check carefully!
