### PR TITLE
check_amperfs tidying

### DIFF
--- a/bin/check_amperfs
+++ b/bin/check_amperfs
@@ -176,22 +176,24 @@ def main(data_dct, ratio_bounds, busy_aperf_threshold):
     print("# Pexecs examined: %s" % pexecs_checked)
 
 
+def fatal(msg):
+    sys.stderr.write("%s\n" % msg)
+    sys.exit(1)
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 5:
-        print(__doc__)
-        sys.exit(1)
+        fatal(__doc__)
 
     try:
         lo_ratio, hi_ratio = sys.argv[2].split(",")
         ratio_bounds = float(lo_ratio), float(hi_ratio)
         busy_aperf_threshold = float(sys.argv[3]) / float(sys.argv[4])
     except:
-        print(__doc__)
-        sys.exit(1)
+        fatal(__doc__)
 
     data_dct = read_krun_results_file(sys.argv[1])
     if "all_outliers" not in data_dct:
-        print("please supply a results file with outlier annotated")
-        sys.exit(1)
+        fatal("Please supply a results file with outlier annotated")
 
     main(data_dct, ratio_bounds, busy_aperf_threshold)

--- a/bin/check_amperfs
+++ b/bin/check_amperfs
@@ -190,4 +190,8 @@ if __name__ == "__main__":
         sys.exit(1)
 
     data_dct = read_krun_results_file(sys.argv[1])
+    if "all_outliers" not in data_dct:
+        print("please supply a results file with outlier annotated")
+        sys.exit(1)
+
     main(data_dct, ratio_bounds, busy_aperf_threshold)

--- a/bin/check_amperfs
+++ b/bin/check_amperfs
@@ -38,7 +38,7 @@
 # SOFTWARE.
 
 """
-usage: check_amperfs.py <results_file> <aperf/mperf-ratio-bounds>
+usage: check_amperfs <results_file> <aperf/mperf-ratio-bounds>
             <busy-aperf-count-estimate> <busy-threshold-factor>
 
 Checks if the CPU has clocked down or entered turbo mode during Krun

--- a/bin/check_amperfs.py
+++ b/bin/check_amperfs.py
@@ -94,9 +94,8 @@ def recently_migrated(aperfs, iter_idx, busy_threshold, migration_lookback):
 
 
 def check_amperfs(aperfs, mperfs, wcts, busy_threshold, ratio_bounds, key,
-                  pexec_idx, core_idx, migration_lookback, cycles,
-                  all_cores_aperfs, all_cores_mperfs, all_cores_cycles,
-                  outliers):
+                  pexec_idx, core_idx, migration_lookback, all_cores_aperfs,
+                  all_cores_mperfs, outliers):
     assert len(aperfs) == len(mperfs) == len(wcts)
 
     iter_idx = 0
@@ -137,7 +136,6 @@ def main(data_dct, ratio_bounds, busy_aperf_threshold, migration_lookback):
     for key, key_wcts in data_dct["wallclock_times"].iteritems():
         key_aperfs = data_dct["aperf_counts"][key]
         key_mperfs = data_dct["mperf_counts"][key]
-        key_cycles = data_dct["core_cycle_counts"][key]
         key_outliers = data_dct["all_outliers"][key]
         assert len(key_aperfs) == len(key_mperfs) == len(key_wcts), \
             "pexec count should match"
@@ -147,8 +145,6 @@ def main(data_dct, ratio_bounds, busy_aperf_threshold, migration_lookback):
             pexec_aperfs = key_aperfs[pexec_idx]
             pexec_mperfs = key_mperfs[pexec_idx]
             pexec_wcts = key_wcts[pexec_idx]
-            pexec_cycles = key_cycles[pexec_idx]
-            pexec_cycles = key_cycles[pexec_idx]
             pexec_outliers = key_outliers[pexec_idx]
             assert len(pexec_aperfs) == len(pexec_mperfs), \
                 "core count should match for a/mperfs"
@@ -157,13 +153,11 @@ def main(data_dct, ratio_bounds, busy_aperf_threshold, migration_lookback):
             for core_idx in xrange(len(pexec_aperfs)):
                 core_aperfs = pexec_aperfs[core_idx]
                 core_mperfs = pexec_mperfs[core_idx]
-                core_cycles = pexec_cycles[core_idx]
 
                 violating_iterations_core = check_amperfs(
                     core_aperfs, core_mperfs, pexec_wcts, busy_aperf_threshold,
                     ratio_bounds, key, pexec_idx, core_idx, migration_lookback,
-                    core_cycles, pexec_aperfs, pexec_mperfs, pexec_cycles,
-                    pexec_outliers)
+                    pexec_aperfs, pexec_mperfs, pexec_outliers)
                 violating_iterations_pexec |= violating_iterations_core
                 if violating_iterations_core:
                     bad_pexec = True


### PR DESCRIPTION
This script was doing the right thing, but had inaccurate help messages, misleading variable names and unused code. The only functional change is a check that the data has outliers annotated.

I've tested with the 0.8 data and can confirm that we get the same outcome, i.e. 10 affected pexecs, 8 on bencher7, 2 on bencher5.

OK?