### PR TITLE
Don't check A/MPERF ratios for the startup experiment.

### DIFF
--- a/startup.krun
+++ b/startup.krun
@@ -78,4 +78,9 @@ BENCHMARKS = {
     'binarytrees': 18,
 }
 
+# Do not check A/MPERF ratios for the startup experiment.
+del(BUSY_THRESHOLDS)
+del(AMPERF_RATIO_BOUNDS)
+del(AMPERF_BUSY_THRESHOLD)
+
 N_EXECUTIONS = 200  # Number of fresh processes.


### PR DESCRIPTION
This fixes the startup crash.

Once merged to the master branch I propose I make a hotfix branch off of the `warmup_experiment_results_v1.2` tag and cherry pick this commit.

Then we can restart bencher6 and 7 (5 is a bit behind, still running the main warmup experiment).

Sounds good?