### PR TITLE
Only delete the AMPERF configuration if it exists.

### DIFF
--- a/startup.krun
+++ b/startup.krun
@@ -79,8 +79,9 @@ BENCHMARKS = {
 }
 
 # Do not check A/MPERF ratios for the startup experiment.
-del(BUSY_THRESHOLDS)
-del(AMPERF_RATIO_BOUNDS)
-del(AMPERF_BUSY_THRESHOLD)
+if "AMPERF_RATIO_BOUNDS" in globals():
+    del(BUSY_THRESHOLDS)
+    del(AMPERF_RATIO_BOUNDS)
+    del(AMPERF_BUSY_THRESHOLD)
 
 N_EXECUTIONS = 200  # Number of fresh processes.


### PR DESCRIPTION
Stops bencher6 crashing.

OK?