### PR TITLE
Give up on running lusearch. Keeps hanging (on both graal and jdk).

### DIFF
--- a/extbench/rundacapo.py
+++ b/extbench/rundacapo.py
@@ -14,7 +14,8 @@ ITERATIONS = 2000
 PROCESSES = 30
 
 # broken: batik, eclipse, tomcat
-WORKING_BENCHS   = ['avrora', 'fop', 'h2', 'jython', 'luindex', 'lusearch',
+# hanging (sometimes): lusearch
+WORKING_BENCHS   = ['avrora', 'fop', 'h2', 'jython', 'luindex',
                     'pmd', 'sunflow', 'tradebeans', 'tradesoap', 'xalan']
 
 # These fail with a socket error on OpenBSD/JVM, even with the firewall off.


### PR DESCRIPTION
I must have restarted dacapo on Linux 3 or 4 times now. It always gets stuck on lusearch. Initially I though this was local to graal, but no. Let's disable it so we can progress.

OK?

Note: merge base is the hotfix branch.