### PR TITLE
Don't clean /tmp during benchmarks please.

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -172,6 +172,9 @@ if sys.platform.startswith("linux"):
         "sudo systemctl stop cron",
         "sudo systemctl stop atd",
         "sudo systemctl stop postfix",
+        "sudo systemctl stop systemd-tmpfiles-clean.timer",
+        "sudo systemctl stop dbus",
+        "sudo systemctl stop dbus.socket",
         "sudo systemctl stop ssh",
     ]
 
@@ -183,6 +186,12 @@ if sys.platform.startswith("linux"):
         "sudo systemctl start cron || true",
         "sudo systemctl start atd || true",
         "sudo systemctl start postfix || true",
+        "sudo systemctl start systemd-tmpfiles-clean.timer || true",
+        "sudo systemctl start dbus",
+        "sudo systemctl start dbus.socket",
+        # these will have been taken down by dbus going down
+        "sudo systemctl start console-kit-daemon",
+        "sudo systemctl start polkitd",
     ]
 elif sys.platform.startswith("openbsd"):
     PRE_EXECUTION_CMDS = [


### PR DESCRIPTION
Prompted by #451 I've re-audited system services, and found one more to kill:

```
systemd-tmpfiles-clean.timer      loaded active waiting   Daily Cleanup of Temporary Directories
```

We don't want /tmp to be cleaned mid-benchmark.

Still testing, so hold off merge for now.

Looks good?