### PR TITLE
Use a hand-rolled V8 tarball to *really* ensure The versions are fixed.

### DIFF
--- a/bin/make_v8_source_tarball
+++ b/bin/make_v8_source_tarball
@@ -1,0 +1,69 @@
+#! /bin/sh
+#
+# Roll a "frozen" V8 source tarball.
+
+set -e
+
+DIRNAME=`dirname $0`
+TOPDIR=`readlink -f ${DIRNAME}/..`
+WRKDIR=${TOPDIR}/work
+
+mkdir -p ${WRKDIR}
+echo "===> Working in $WRKDIR"
+
+# Look here to know which V8 branch is currently stable:
+# https://omahaproxy.appspot.com/
+#
+# Note that there is often a newer tag in git than is shown on that page.
+# Make sure you check the tags for the stable branch. Don't use the github
+# mirror to look for tags, as it doesn't have them all.
+#
+# XXX If you are updating the V8 version, you probably want to change/remove
+# the part of this script that rewinds the git versions of the dependencies.
+# Perhaps checkout the deps with the same date as the V8 release instead (then
+# you can also kill fix_v8_versions and find_v8_git_versions too)
+V8_V=5.8.283.32
+V8_TARBALL=v8_fullsource_${V8_V}_`date +%F`.tar.gz
+
+cd ${WRKDIR}
+
+if [ -f ${WRKDIR}/${V8_TARBALL} ]; then
+    echo "tarball already exists"
+fi
+
+# The build requires that you clone using this git wrapper: depot_tools
+#
+# We've tried using a fixed version of depot tools in the past. It has a
+# tendency to update itself and switching of auto-update causes other
+# problems.
+if [ ! -d ${WRKDIR}/depot_tools ]; then
+    git clone "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+fi
+
+cd ${WRKDIR}
+PATH=${WRKDIR}/cpython-inst/bin:${WRKDIR}/depot_tools:${PATH}
+
+# Fetch sources
+if [ ! -d ${WRKDIR}/v8 ]; then
+    # V8 won't let you 'fetch' into a git sandbox
+    v8tmp=`mktemp -d`
+    cd ${v8tmp} && fetch --nohooks v8
+    mv ${v8tmp}/v8 ${v8tmp}/.gclient* ${WRKDIR}
+fi
+cd ${WRKDIR}/v8
+git checkout ${V8_V}
+
+# depot tools fetches non-fixed versions of stuff. This script rewinds the
+# many repositories it has fetched to fixed versions. The script we call
+# here is auto-generated.
+sh -x ${TOPDIR}/bin/fix_v8_versions
+
+# Make tarball smaller
+find ${WRKDIR}/v8 -name '.git' -type 'd' | xargs rm -rf
+
+# Tar it up
+cd ${WRKDIR}
+tar zcf ${V8_TARBALL} v8
+
+echo "\n\n"
+ls -al ${WRKDIR}/${V8_TARBALL}


### PR DESCRIPTION
depot_tools continues to cause us problems. 

To fix this, I've used a sledgehammer approach to ensure that there is absolutely no way that we can get different code between builds.

This change:
 * Adds a script to make a V8 tarball
 * Changes `build.sh` to use the tarball.

This means a regular build never uses depot_tools, only the script to make tarballs.

Still testing (compiling as we speak, then we should do a small run of V8 only).

If tests succeed, I will upload the tarball to archive.org and have the script fetch it.

Approach seems sound?

I also raised an issue upstream, since the inability to build a frozen version of V8 seems like a shortcoming:
https://bugs.chromium.org/p/v8/issues/detail?id=7107