### PR TITLE
Don't fail if the stop cookie host is unreachable.

### DIFF
--- a/warmup.krun
+++ b/warmup.krun
@@ -218,12 +218,16 @@ else:
 # SSH server hostname is temporarily unavailable.
 REMOTE_LOGIN = "vext01@bencher8.soft-dev.org"
 REMOTE_DIR = "research/krun_results/"
-
+COOKIE_PATH = os.path.join(REMOTE_DIR, HOSTNAME + ".stop")
 SSH_BATCH = "ssh -o 'BatchMode yes' -i id_rsa"
+
 SCP_CMD = ("tar czf - ${KRUN_RESULTS_FILE} ${KRUN_LOG_FILE} ${KRUN_MANIFEST_FILE} | "
            "%s %s 'cat > %s/%s.tgz'" %
            (SSH_BATCH, REMOTE_LOGIN, REMOTE_DIR, HOSTNAME))
 POST_EXECUTION_CMDS.append(
     "%s || ( sleep 2; %s ) || true " % (SCP_CMD, SCP_CMD))
-POST_EXECUTION_CMDS.append("%s %s 'test ! -e %s/%s.stop'" %
-                           (SSH_BATCH, REMOTE_LOGIN, REMOTE_DIR, HOSTNAME))
+
+# Crash if the "stop cookie" exists on the remote host.
+# Allows us to stop machines with no remote management.
+POST_EXECUTION_CMDS.append("{0} {1} ls {2} 2> /dev/null | grep {2}; exit $((! $?))".format(
+    SSH_BATCH, REMOTE_LOGIN, COOKIE_PATH))


### PR DESCRIPTION
Currently the experiment will fail the stop cookie host is unreachable. This means intermittent network failures will stop the experiment.

This change puts a `ping -qc3 cookie-host || return 0 &&` before the cookie check command. This means that if the cookie-host isn't reachable, the command returns 0 allowing the experiment to continue.

How it works (using simplified shell command):

cookie host reachable, command after returns 0 (i.e. cookie not present):
```
vext01@bencher8:~$ sh -c "ping -qc3 google.com || exit 0 && echo hi"
PING google.com (216.58.206.78) 56(84) bytes of data.

--- google.com ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2003ms
rtt min/avg/max/mdev = 2.295/2.316/2.335/0.042 ms
hi
vext01@bencher8:~$ echo $?
0
```

cookie host reachable, command after fails (i.e. cookie exists):
```
vext01@bencher8:~$ sh -c "ping -qc3 google.com || exit 0 && fudge"
PING google.com (216.58.206.78) 56(84) bytes of data.

--- google.com ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 2003ms
rtt min/avg/max/mdev = 2.299/2.319/2.338/0.015 ms
sh: 1: fudge: not found
vext01@bencher8:~$ echo $?
127
```

cookie host not reachable, command after not executed, but return is 0:
```
vext01@bencher8:~$ sh -c "ping -qc3 ssssssssgoogle.com || exit 0 && echo NOT_ECHOED"
ping: ssssssssgoogle.com: Name or service not known
vext01@bencher8:~$ echo $?
0
```

Does this look right to you? Tested on bencher6.