### PR TITLE
Update Makefile wrt APIs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ bench-octane:
 plot-warmup-results:
 	warmup_stats/bin/mark_outliers_in_json -w ${WINDOW_SIZE} -t ${OUTLIER_THRESHOLD} warmup_results.json.bz2
 	warmup_stats/bin/mark_changepoints_in_json -s ${STEADY_STATE_EXPECTED} warmup_results_outliers_w${WINDOW_SIZE}.json.bz2
-	warmup_stats/bin/plot_krun_results -w ${WINDOW_SIZE} -m -t --with-outliers -o warmup_${PLOTS_NO_CPTS} warmup_results_outliers_w${WINDOW_SIZE}.json.bz2
-	warmup_stats/bin/plot_krun_results -w ${WINDOW_SIZE} -m -t --with-outliers --with-changepoints -o warmup_${PLOTS_WITH_CPTS} warmup_results_outliers_w${WINDOW_SIZE}_changepoints.json.bz2
+	warmup_stats/bin/plot_krun_results --with-outliers -o warmup_${PLOTS_NO_CPTS} warmup_results_outliers_w${WINDOW_SIZE}.json.bz2
+	warmup_stats/bin/plot_krun_results --with-outliers --with-changepoints -o warmup_${PLOTS_WITH_CPTS} warmup_results_outliers_w${WINDOW_SIZE}_changepoints.json.bz2
 
 plot-warmup-outliers-by-threshold:
 	bin/calculate_outliers_by_threshold warmup_results.json.bz2
@@ -94,14 +94,14 @@ plot-dacapo-results:
 	warmup_stats/bin/csv_to_krun_json -u "`uname -a`" -v HotSpot -l Java dacapo.hotspot.results
 	warmup_stats/bin/mark_outliers_in_json -w ${WINDOW_SIZE} -t ${OUTLIER_THRESHOLD} dacapo.hotspot.json.bz2
 	LD_LIBRARY_PATH=${R_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH} warmup_stats/bin/mark_changepoints_in_json -s ${STEADY_STATE_EXPECTED} dacapo.hotspot_outliers_w${WINDOW_SIZE}.json.bz2
-	warmup_stats/bin/plot_krun_results --wallclock-only -w ${WINDOW_SIZE} -m -t --with-outliers -o dacapo.hotspot_${PLOTS_NO_CPTS} dacapo.hotspot_outliers_w${WINDOW_SIZE}.json.bz2
-	warmup_stats/bin/plot_krun_results --wallclock-only -w ${WINDOW_SIZE} -m -t --with-outliers --with-changepoints -o dacapo.hotspot_${PLOTS_WITH_CPTS} dacapo.hotspot_outliers_w${WINDOW_SIZE}_changepoints.json.bz2
+	warmup_stats/bin/plot_krun_results --wallclock-only --with-outliers -o dacapo.hotspot_${PLOTS_NO_CPTS} dacapo.hotspot_outliers_w${WINDOW_SIZE}.json.bz2
+	warmup_stats/bin/plot_krun_results --wallclock-only --with-outliers --with-changepoints -o dacapo.hotspot_${PLOTS_WITH_CPTS} dacapo.hotspot_outliers_w${WINDOW_SIZE}_changepoints.json.bz2
 	if [ -e dacapo.graal.results ]; then \
 		warmup_stats/bin/csv_to_krun_json -u "`uname -a`" -v Graal -l Java dacapo.graal.results && \
 		warmup_stats/bin/mark_outliers_in_json -w ${WINDOW_SIZE} -t ${OUTLIER_THRESHOLD} dacapo.graal.json.bz2 && \
 		LD_LIBRARY_PATH=${R_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH} warmup_stats/bin/mark_changepoints_in_json -s ${STEADY_STATE_EXPECTED} dacapo.graal_outliers_w${WINDOW_SIZE}.json.bz2 && \
-		warmup_stats/bin/plot_krun_results --wallclock-only -w ${WINDOW_SIZE} -m -t --with-outliers -o dacapo.graal_${PLOTS_NO_CPTS} dacapo.graal_outliers_w${WINDOW_SIZE}.json.bz2 && \
-		warmup_stats/bin/plot_krun_results --wallclock-only -w ${WINDOW_SIZE} -m -t --with-outliers --with-changepoints -o dacapo.graal_${PLOTS_WITH_CPTS} dacapo.graal_outliers_w${WINDOW_SIZE}_changepoints.json.bz2; \
+		warmup_stats/bin/plot_krun_results --wallclock-only --with-outliers -o dacapo.graal_${PLOTS_NO_CPTS} dacapo.graal_outliers_w${WINDOW_SIZE}.json.bz2 && \
+		warmup_stats/bin/plot_krun_results --wallclock-only --with-outliers --with-changepoints -o dacapo.graal_${PLOTS_WITH_CPTS} dacapo.graal_outliers_w${WINDOW_SIZE}_changepoints.json.bz2; \
 	fi
 
 # Note: Spidermonkey is skipped on OpenBSD
@@ -109,14 +109,14 @@ plot-octane-results:
 	warmup_stats/bin/csv_to_krun_json -u "`uname -a`" -v V8 -l JavaScript octane.v8.results
 	warmup_stats/bin/mark_outliers_in_json -w ${WINDOW_SIZE} -t ${OUTLIER_THRESHOLD} octane.v8.json.bz2
 	LD_LIBRARY_PATH=${R_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH} warmup_stats/bin/mark_changepoints_in_json -s ${STEADY_STATE_EXPECTED} octane.v8_outliers_w${WINDOW_SIZE}.json.bz2
-	warmup_stats/bin/plot_krun_results --wallclock-only -w ${WINDOW_SIZE} -m -t --with-outliers -o octane.v8_${PLOTS_NO_CPTS} octane.v8_outliers_w${WINDOW_SIZE}.json.bz2
-	warmup_stats/bin/plot_krun_results --wallclock-only -w ${WINDOW_SIZE} -m -t --with-outliers --with-changepoints -o octane.v8_${PLOTS_WITH_CPTS} octane.v8_outliers_w${WINDOW_SIZE}_changepoints.json.bz2
+	warmup_stats/bin/plot_krun_results --with-outliers -o octane.v8_${PLOTS_NO_CPTS} octane.v8_outliers_w${WINDOW_SIZE}.json.bz2
+	warmup_stats/bin/plot_krun_results --with-outliers --with-changepoints -o octane.v8_${PLOTS_WITH_CPTS} octane.v8_outliers_w${WINDOW_SIZE}_changepoints.json.bz2
 	if [ -e octane.spidermonkey.results ]; then \
 		warmup_stats/bin/csv_to_krun_json -u "`uname -a`" -v SpiderMonkey -l JavaScript octane.spidermonkey.results && \
 		warmup_stats/bin/mark_outliers_in_json -w ${WINDOW_SIZE} -t ${OUTLIER_THRESHOLD} octane.spidermonkey.json.bz2 && \
 		LD_LIBRARY_PATH=${R_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH} warmup_stats/bin/mark_changepoints_in_json -s ${STEADY_STATE_EXPECTED} octane.spidermonkey_outliers_w${WINDOW_SIZE}.json.bz2 && \
-		warmup_stats/bin/plot_krun_results --wallclock-only -w ${WINDOW_SIZE} -m -t --with-outliers -o octane.spidermonkey_${PLOTS_NO_CPTS} octane.spidermonkey_outliers_w${WINDOW_SIZE}.json.bz2 && \
-		warmup_stats/bin/plot_krun_results --wallclock-only -w ${WINDOW_SIZE} -m -t --with-outliers --with-changepoints -o octane.spidermonkey_${PLOTS_WITH_CPTS} octane.spidermonkey_outliers_w${WINDOW_SIZE}_changepoints.json.bz2; \
+		warmup_stats/bin/plot_krun_results --wallclock-only --with-outliers -o octane.spidermonkey_${PLOTS_NO_CPTS} octane.spidermonkey_outliers_w${WINDOW_SIZE}.json.bz2 && \
+		warmup_stats/bin/plot_krun_results --wallclock-only --with-outliers --with-changepoints -o octane.spidermonkey_${PLOTS_WITH_CPTS} octane.spidermonkey_outliers_w${WINDOW_SIZE}_changepoints.json.bz2; \
 	fi
 
 tables-warmup:


### PR DESCRIPTION
The plotting script has removed -m and -t features altogether. -w is now gone, and instead the plotting script picks up the window size from the JSON input files.

@vext01 for me the `build.sh` script builds warmup stats OK, and I think that the CLI changes here match the version of the repo we are downloading, but I'm not sure how we can sensibly check?